### PR TITLE
Included Elgato's Eve Homekit App Graphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ Configuration sample:
 - ~~update temperature~~
 - ~~get device name~~
 - ~~set target temperature~~ (credits to zizzex)
+
+# Notes
+
+It seems to be vitally important to set the right system time, especially on raspi!

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This plugin is not yet on NPM. Insatllation only via GitHub at the moment...
 Configuration sample:
 
 ```
-"platform": [
+"platforms": [
         {
             "platform": "Evohome",
             "name" : "Evohome",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # homebridge-evohome
 
+***!Attention: The old Version (<0.1.1) is no longer working due to a change in the API-URL. Please update.***
+
 This ia a plugin for Honeywell evohome. It is a partially-working implementation into HomeKit. This plugin is work in progress. Help is appreciated!
 
 # Installation
@@ -38,6 +40,8 @@ Configuration sample:
 - ~~update temperature~~
 - ~~get device name~~
 - ~~set target temperature~~ (credits to zizzex)
+- change temperature until next scheduled event (now 10 minutes)
+- add "global device" to add Away/Energy saving etc.
 
 # Notes
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Configuration sample:
 - ~~set target temperature~~ (credits to zizzex)
 - change temperature until next scheduled event (now 10 minutes)
 - add "global device" to add Away/Energy saving etc.
+- add "DOMESTIC_HOT_WATER" with matching characteristics
 
 # Notes
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This ia a plugin for Honeywell evohome. It is a partially-working implementation
 This plugin is not yet on NPM. Insatllation only via GitHub at the moment...
 
 1. Install homebridge using: npm install -g homebridge <br>
-2. Install this plugin using npm install -g git+https://git@github.com/luc-ass/homebridge-evohome
+2. Install this plugin using npm install -g homebridge-evohome
 3. Update your configuration file. See sample-config below for a sample.
 
 # Configuration

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This ia a plugin for Honeywell evohome. It is a partially-working implementation into HomeKit. This plugin is work in progress. Help is appreciated!
 
+Up until now this plugin will only add your Thermostats to Homebridge. Other devices such as domestic hot water or the central unit itself with modes such as away or vacation will probably follow in the future once the basic problems are fixed.
+
 # Installation
 
 This plugin is not yet on NPM. Insatllation only via GitHub at the moment...

--- a/index.js
+++ b/index.js
@@ -17,151 +17,151 @@ var Service, Characteristic;
 var config;
 
 module.exports = function(homebridge) {
-  Service = homebridge.hap.Service;
-  Characteristic = homebridge.hap.Characteristic;
-  
-  homebridge.registerPlatform("homebridge-evohome", "Evohome", EvohomePlatform);
+    Service = homebridge.hap.Service;
+    Characteristic = homebridge.hap.Characteristic;
+    
+    homebridge.registerPlatform("homebridge-evohome", "Evohome", EvohomePlatform);
 }
 
 function EvohomePlatform(log, config){
-
-	this.username = config['username'];
-	this.password = config['password'];
-	this.temperatureUnit = config['temperatureUnit'];
     
-  this.cache_timeout = 300; // seconds
-
-	this.log = log;
+    this.username = config['username'];
+    this.password = config['password'];
+    this.temperatureUnit = config['temperatureUnit'];
     
-  this.updating = false;
+    this.cache_timeout = 300; // seconds
+    
+    this.log = log;
+    
+    this.updating = false;
 }
 
 EvohomePlatform.prototype = {
-	accessories: function(callback) {
-		this.log("Logging into Evohome...");
-
-		var that = this;
-		// create the myAccessories array
-		this.myAccessories = [];
-
-		evohome.login(that.username, that.password).then(function(session) {
-			this.log("Logged into Evohome!");
-
-			session.getLocations().then(function(locations){
-				this.log('You have', locations.length, 'location(s). Only the first one will be used!');
-				this.log('You have', locations[0].devices.length, 'device(s).')
-				
-				session.getThermostats(locations[0].locationID).then(function(thermostats){
-
-				// iterate through the devices
-				for (var deviceId in locations[0].devices) {
-				    for(var thermoId in thermostats) {
-				        if(locations[0].devices[deviceId].zoneID == thermostats[thermoId].zoneId) {
-				            // print name of the device
-					        this.log(deviceId + ": " + locations[0].devices[deviceId].name + " (" + thermostats[thermoId].temperatureStatus.temperature + "°)");
-
-                            if(locations[0].devices[deviceId].name  == "") {
-                                // Device name is empty
-                                // Probably Hot Water
-                                // Do not store
-                                this.log("Found blank device name, probably stored hot water. Ignoring device for now.");
-                            }
-                            else {
-						    // store device in var
-						    var device = locations[0].devices[deviceId];
-						    // store thermostat in var
-						    var thermostat = thermostats[thermoId];
-						    // store name of device
-						    var name = locations[0].devices[deviceId].name + " Thermostat";
-						    // create accessory (only if it is "HeatingZone")
-						    if (device.modelType = "HeatingZone") {
-							    var accessory = new EvohomeThermostatAccessory(that.log, name, device, deviceId, thermostat, this.temperatureUnit, this.username, this.password);
-							    // store accessory in myAccessories
-							    this.myAccessories.push(accessory);
-						    }
-                            }
-				        }
-				    }
-				}
-
-				callback(this.myAccessories);
-                                        
-                setInterval(that.periodicUpdate.bind(this), this.cache_timeout * 1000);
-                
-                }.bind(this)).fail(function(err){
-                    that.log('Evohome failed:', err);
-                });
-
-			}.bind(this)).fail(function(err){
-				that.log('Evohome Failed:', err);
-			});
-
-
-		}.bind(this)).fail(function(err) {
-			// tell me if login did not work!
-			that.log("Error during Login:", err);
-		});
-	}
+accessories: function(callback) {
+    this.log("Logging into Evohome...");
+    
+    var that = this;
+    // create the myAccessories array
+    this.myAccessories = [];
+    
+    evohome.login(that.username, that.password).then(function(session) {
+                                                     this.log("Logged into Evohome!");
+                                                     
+                                                     session.getLocations().then(function(locations){
+                                                                                 this.log('You have', locations.length, 'location(s). Only the first one will be used!');
+                                                                                 this.log('You have', locations[0].devices.length, 'device(s).')
+                                                                                 
+                                                                                 session.getThermostats(locations[0].locationID).then(function(thermostats){
+                                                                                                                                      
+                                                                                                                                      // iterate through the devices
+                                                                                                                                      for (var deviceId in locations[0].devices) {
+                                                                                                                                      for(var thermoId in thermostats) {
+                                                                                                                                      if(locations[0].devices[deviceId].zoneID == thermostats[thermoId].zoneId) {
+                                                                                                                                      // print name of the device
+                                                                                                                                      this.log(deviceId + ": " + locations[0].devices[deviceId].name + " (" + thermostats[thermoId].temperatureStatus.temperature + "°)");
+                                                                                                                                      
+                                                                                                                                      if(locations[0].devices[deviceId].name  == "") {
+                                                                                                                                      // Device name is empty
+                                                                                                                                      // Probably Hot Water
+                                                                                                                                      // Do not store
+                                                                                                                                      this.log("Found blank device name, probably stored hot water. Ignoring device for now.");
+                                                                                                                                      }
+                                                                                                                                      else {
+                                                                                                                                      // store device in var
+                                                                                                                                      var device = locations[0].devices[deviceId];
+                                                                                                                                      // store thermostat in var
+                                                                                                                                      var thermostat = thermostats[thermoId];
+                                                                                                                                      // store name of device
+                                                                                                                                      var name = locations[0].devices[deviceId].name + " Thermostat";
+                                                                                                                                      // create accessory (only if it is "HeatingZone")
+                                                                                                                                      if (device.modelType = "HeatingZone") {
+                                                                                                                                      var accessory = new EvohomeThermostatAccessory(that.log, name, device, deviceId, thermostat, this.temperatureUnit, this.username, this.password);
+                                                                                                                                      // store accessory in myAccessories
+                                                                                                                                      this.myAccessories.push(accessory);
+                                                                                                                                      }
+                                                                                                                                      }
+                                                                                                                                      }
+                                                                                                                                      }
+                                                                                                                                      }
+                                                                                                                                      
+                                                                                                                                      callback(this.myAccessories);
+                                                                                                                                      
+                                                                                                                                      setInterval(that.periodicUpdate.bind(this), this.cache_timeout * 1000);
+                                                                                                                                      
+                                                                                                                                      }.bind(this)).fail(function(err){
+                                                                                                                                                         that.log('Evohome failed:', err);
+                                                                                                                                                         });
+                                                                                 
+                                                                                 }.bind(this)).fail(function(err){
+                                                                                                    that.log('Evohome Failed:', err);
+                                                                                                    });
+                                                     
+                                                     
+                                                     }.bind(this)).fail(function(err) {
+                                                                        // tell me if login did not work!
+                                                                        that.log("Error during Login:", err);
+                                                                        });
+}
 };
 
 EvohomePlatform.prototype.periodicUpdate = function(session,myAccessories) {
-
+    
     if(!this.updating && this.myAccessories){
         this.updating = true;
         
         evohome.login(this.username, this.password).then(function(session) {
-        
-            session.getLocations().then(function(locations){
-            
-                session.getThermostats(locations[0].locationID).then(function(thermostats){
-                
-                
-                for (var deviceId in locations[0].devices) {
-				    for(var thermoId in thermostats) {
-				        if(locations[0].devices[deviceId].zoneID == thermostats[thermoId].zoneId) {
-				            for(var i=0; i<this.myAccessories.length; ++i) {
-				                if(this.myAccessories[i].device.zoneID == locations[0].devices[deviceId].zoneID) {
-				                
-				            var device = locations[0].devices[deviceId];
-				            var thermostat = thermostats[thermoId];
-				            
-                            if(device) {
-                                // Check if temp has changed
-                                var oldCurrentTemp = this.myAccessories[i].thermostat.temperatureStatus.temperature;
-                                var newCurrentTemp = thermostat.temperatureStatus.temperature;
-                                        
-                                var service = this.myAccessories[i].thermostatService;
-                                        
-                                if(oldCurrentTemp!=newCurrentTemp && service) {
-                                    this.log("Updating: " + device.name + " currentTempChange from: " + oldCurrentTemp + " to: " + newCurrentTemp);
-                                }
-                                        
-                                var oldTargetTemp = this.myAccessories[i].thermostat.setpointStatus.targetHeatTemperature;
-                                var newTargetTemp = thermostat.setpointStatus.targetHeatTemperature;
-                                
-                                if(oldTargetTemp!=newTargetTemp && service) {
-                                    this.log("Updating: " + device.name + " targetTempChange from: " + oldTargetTemp + " to: " + newTargetTemp);
-                                }
-
-                                this.myAccessories[i].device = device;
-                                this.myAccessories[i].thermostat = thermostat;
-				            }
-				                
-				                }
-				            }
-				        }
-				    }
-				}
-                
-                }.bind(this)).fail(function(err){
-                    this.log('Evohome Failed:', err);
-                });
-            }.bind(this)).fail(function(err){
-                this.log('Evohome Failed:', err);
-            });
-        }.bind(this)).fail(function(err){
-            this.log('Evohome Failed:', err);
-        });
+                                                         
+                                                         session.getLocations().then(function(locations){
+                                                                                     
+                                                                                     session.getThermostats(locations[0].locationID).then(function(thermostats){
+                                                                                                                                          
+                                                                                                                                          
+                                                                                                                                          for (var deviceId in locations[0].devices) {
+                                                                                                                                          for(var thermoId in thermostats) {
+                                                                                                                                          if(locations[0].devices[deviceId].zoneID == thermostats[thermoId].zoneId) {
+                                                                                                                                          for(var i=0; i<this.myAccessories.length; ++i) {
+                                                                                                                                          if(this.myAccessories[i].device.zoneID == locations[0].devices[deviceId].zoneID) {
+                                                                                                                                          
+                                                                                                                                          var device = locations[0].devices[deviceId];
+                                                                                                                                          var thermostat = thermostats[thermoId];
+                                                                                                                                          
+                                                                                                                                          if(device) {
+                                                                                                                                          // Check if temp has changed
+                                                                                                                                          var oldCurrentTemp = this.myAccessories[i].thermostat.temperatureStatus.temperature;
+                                                                                                                                          var newCurrentTemp = thermostat.temperatureStatus.temperature;
+                                                                                                                                          
+                                                                                                                                          var service = this.myAccessories[i].thermostatService;
+                                                                                                                                          
+                                                                                                                                          if(oldCurrentTemp!=newCurrentTemp && service) {
+                                                                                                                                          this.log("Updating: " + device.name + " currentTempChange from: " + oldCurrentTemp + " to: " + newCurrentTemp);
+                                                                                                                                          }
+                                                                                                                                          
+                                                                                                                                          var oldTargetTemp = this.myAccessories[i].thermostat.setpointStatus.targetHeatTemperature;
+                                                                                                                                          var newTargetTemp = thermostat.setpointStatus.targetHeatTemperature;
+                                                                                                                                          
+                                                                                                                                          if(oldTargetTemp!=newTargetTemp && service) {
+                                                                                                                                          this.log("Updating: " + device.name + " targetTempChange from: " + oldTargetTemp + " to: " + newTargetTemp);
+                                                                                                                                          }
+                                                                                                                                          
+                                                                                                                                          this.myAccessories[i].device = device;
+                                                                                                                                          this.myAccessories[i].thermostat = thermostat;
+                                                                                                                                          }
+                                                                                                                                          
+                                                                                                                                          }
+                                                                                                                                          }
+                                                                                                                                          }
+                                                                                                                                          }
+                                                                                                                                          }
+                                                                                                                                          
+                                                                                                                                          }.bind(this)).fail(function(err){
+                                                                                                                                                             this.log('Evohome Failed:', err);
+                                                                                                                                                             });
+                                                                                     }.bind(this)).fail(function(err){
+                                                                                                        this.log('Evohome Failed:', err);
+                                                                                                        });
+                                                         }.bind(this)).fail(function(err){
+                                                                            this.log('Evohome Failed:', err);
+                                                                            });
         
         this.updating = false;
     }
@@ -169,266 +169,252 @@ EvohomePlatform.prototype.periodicUpdate = function(session,myAccessories) {
 
 // give this function all the parameters needed
 function EvohomeThermostatAccessory(log, name, device, deviceId, thermostat, temperatureUnit, username, password) {
-	this.name = name;
-	this.device = device;
-	this.model = device.modelType;
-	this.serial = device.deviceID;
-	this.deviceId = deviceId;
-	
-	this.thermostat = thermostat;
-	this.temperatureUnit = temperatureUnit;
-	
-	this.username = username;
-	this.password = password;
-
-	this.log = log;
+    this.name = name;
+    this.device = device;
+    this.model = device.modelType;
+    this.serial = device.deviceID;
+    this.deviceId = deviceId;
+    
+    this.thermostat = thermostat;
+    this.temperatureUnit = temperatureUnit;
+    
+    this.username = username;
+    this.password = password;
+    
+    this.log = log;
 }
 
 EvohomeThermostatAccessory.prototype = {
-	
-	getCurrentTemperature: function(callback) {
-		var that = this;
-
-		// need to refresh data if outdated!!
-		var currentTemperature = this.thermostat.temperatureStatus.temperature;
-		callback(null, Number(currentTemperature));
-		that.log("Current temperature of " + this.name + " is " + currentTemperature + "°");
-	},
-
-	getCurrentHeatingCoolingState: function(callback) {
-		var that = this;
-
-		that.log("getCurrentHeatingCooling");
-
-		// TODO:
-		// fixed until it can be requested from Evohome...
-		// OFF  = 0
-		// HEAT = 1
-		// COOL = 2
-		// AUTO = 3
-        
-        var mode = this.device.thermostat.changeableValues.mode == "Off" ? 0 : 1;
-        
-        that.log("currentHeatingCooling = " + mode);
-        
-		callback(null, Number(mode));
-
-	},
-
-	getName: function(callback) {
-
-		var that = this;
-
-		that.log("requesting name of", this.name);
-
-		callback(this.name);
-
-	},
-
-	setTargetHeatingCooling: function(value, callback) {
-		var that = this;
-
-		// not implemented 
-
-		that.log("attempted to change targetHeatingCooling: " + value +" - not yet implemented");
-		callback();
-
-	},
-
-	getTargetHeatingCooling: function(callback) {
-		var that = this;
-        
-        that.log("getTargetHeatingCooling");
-
-		// TODO:
-		// fixed until it can be requested from Evohome...
-		// OFF  = 0
-		// HEAT = 1
-		// COOL = 2
-		// AUTO = 3
-        
-        var mode = this.device.thermostat.changeableValues.mode == "Off" ? 0 : 1;
-        
-        that.log("currentTargetHeatingCooling = " + mode);
-        
-		callback(null, Number(mode));
-
-	},
-
-   setTargetTemperature: function(value, callback) {
-	  var that = this;
-		
+    
+getCurrentTemperature: function(callback) {
+    var that = this;
+    
+    // need to refresh data if outdated!!
+    var currentTemperature = this.thermostat.temperatureStatus.temperature;
+    callback(null, Number(currentTemperature));
+    that.log("Current temperature of " + this.name + " is " + currentTemperature + "°");
+},
+    
+getCurrentHeatingCoolingState: function(callback) {
+    var that = this;
+    
+    that.log("getCurrentHeatingCooling");
+    
+    // TODO:
+    // fixed until it can be requested from Evohome...
+    // OFF  = 0
+    // HEAT = 1
+    // COOL = 2
+    // AUTO = 3
+    callback(null, Number(1));
+    
+},
+    
+getName: function(callback) {
+    
+    var that = this;
+    
+    that.log("requesting name of", this.name);
+    
+    callback(this.name);
+    
+},
+    
+setTargetHeatingCooling: function(value, callback) {
+    var that = this;
+    
+    // not implemented
+    
+    that.log("attempted to change targetHeatingCooling: " + value +" - not yet implemented");
+    callback();
+    
+},
+    
+getTargetHeatingCooling: function(callback) {
+    var that = this;
+    
+    // TODO:
+    // fixed until it can be requested from Evohome...
+    // OFF  = 0
+    // HEAT = 1
+    // COOL = 2
+    // AUTO = 3
+    callback(null, Number(1));
+    
+},
+    
+setTargetTemperature: function(value, callback) {
+    var that = this;
+    
     evohome.login(this.username, this.password).then(function (session) {
-      session.getSchedule(that.device.zoneID).then(function (schedule) {
-        
-        var date = new Date();
-        var weekdayNumber = date.getDay();
-        var weekday = new Array(7);
-        weekday[0]="Monday";
-        weekday[1]="Tuesday";
-        weekday[2]="Wednesday";
-        weekday[3]="Thursday";
-        weekday[4]="Friday";
-        weekday[5]="Saturday";
-        weekday[6]="Sunday";
-        
-        var currenttime = date.toLocaleTimeString();
-        var proceed = true;
-        var nextScheduleTime = "";
-        
-        for(var scheduleId in schedule) {
-          if(schedule[scheduleId].dayOfWeek == weekday[weekdayNumber]) {
-            var switchpoints = schedule[scheduleId].switchpoints;
-            for(var switchpointId in switchpoints) {
-              if(proceed == true) {
-                if(currenttime >= switchpoints[switchpointId].timeOfDay) {
-                  proceed = true;
-                } else if (currenttime < switchpoints[switchpointId].timeOfDay) {
-                  proceed = false;
-                  nextScheduleTime = switchpoints[switchpointId].timeOfDay;
-                }
-              }
-            }
-            if(proceed == true) {
-                nextScheduleTime = "00:00:00";
-            }
-          }
-        }
-        
-        that.log("Setting target temperature for", that.name, "to", value + "° until " + nextScheduleTime);
-
-        session.setHeatSetpoint(that.device.zoneID, value, nextScheduleTime).then(function (taskId) {
-          that.log("Successfully changed temperature!");
-          that.log(taskId);
-          // returns taskId if successful
-          that.thermostat.setpointStatus.targetHeatTemperature = value;
-          // set target temperature here also to prevent from setting temperature two times
-          // nothing else here...
-          callback(null, Number(1));
-        });
-      }).fail(function(err) {
-          that.log('Evohome failed:', err);
-          callback(null, Number(0));
-      });
-    }).fail(function (err) {
-      that.log('Evohome Failed:', err);
-      callback(null, Number(0));
-    });
+                                                     session.getSchedule(that.device.zoneID).then(function (schedule) {
+                                                                                                  
+                                                                                                  var date = new Date();
+                                                                                                  var weekdayNumber = date.getDay();
+                                                                                                  var weekday = new Array(7);
+                                                                                                  weekday[0]="Monday";
+                                                                                                  weekday[1]="Tuesday";
+                                                                                                  weekday[2]="Wednesday";
+                                                                                                  weekday[3]="Thursday";
+                                                                                                  weekday[4]="Friday";
+                                                                                                  weekday[5]="Saturday";
+                                                                                                  weekday[6]="Sunday";
+                                                                                                  
+                                                                                                  var currenttime = date.toLocaleTimeString();
+                                                                                                  var proceed = true;
+                                                                                                  var nextScheduleTime = "";
+                                                                                                  
+                                                                                                  for(var scheduleId in schedule) {
+                                                                                                  if(schedule[scheduleId].dayOfWeek == weekday[weekdayNumber]) {
+                                                                                                  var switchpoints = schedule[scheduleId].switchpoints;
+                                                                                                  for(var switchpointId in switchpoints) {
+                                                                                                  if(proceed == true) {
+                                                                                                  if(currenttime >= switchpoints[switchpointId].timeOfDay) {
+                                                                                                  proceed = true;
+                                                                                                  } else if (currenttime < switchpoints[switchpointId].timeOfDay) {
+                                                                                                  proceed = false;
+                                                                                                  nextScheduleTime = switchpoints[switchpointId].timeOfDay;
+                                                                                                  }
+                                                                                                  }
+                                                                                                  }
+                                                                                                  if(proceed == true) {
+                                                                                                  nextScheduleTime = "00:00:00";
+                                                                                                  }
+                                                                                                  }
+                                                                                                  }
+                                                                                                  
+                                                                                                  that.log("Setting target temperature for", that.name, "to", value + "° until " + nextScheduleTime);
+                                                                                                  
+                                                                                                  session.setHeatSetpoint(that.device.zoneID, value, nextScheduleTime).then(function (taskId) {
+                                                                                                                                                                            that.log("Successfully changed temperature!");
+                                                                                                                                                                            that.log(taskId);
+                                                                                                                                                                            // returns taskId if successful
+                                                                                                                                                                            that.thermostat.setpointStatus.targetHeatTemperature = value;
+                                                                                                                                                                            // set target temperature here also to prevent from setting temperature two times
+                                                                                                                                                                            // nothing else here...
+                                                                                                                                                                            callback(null, Number(1));
+                                                                                                                                                                            });
+                                                                                                  }).fail(function(err) {
+                                                                                                          that.log('Evohome failed:', err);
+                                                                                                          callback(null, Number(0));
+                                                                                                          });
+                                                     }).fail(function (err) {
+                                                             that.log('Evohome Failed:', err);
+                                                             callback(null, Number(0));
+                                                             });
     callback(null, Number(0));
-  },
-
-	getTargetTemperature: function(callback) {
-		var that = this;
-        
+},
+    
+getTargetTemperature: function(callback) {
+    var that = this;
+    
+    // gives back the target temperature of thermostat
+    // crashes the plugin IF there is no value defined (like
+    // with DOMESTIC_HOT_WATER) so we need to chek if it
+    // is defined first
+    if (this.model = "HeatingZone"){
+        var targetTemperature = this.thermostat.setpointStatus.targetHeatTemperature;
+        that.log("Device type is: " + this.model + ". Target temperature should be there.");
+        that.log("Target temperature for", this.name, "is", targetTemperature + "°");
+    } else {
         var targetTemperature = 0;
-
-		// gives back the target temperature of thermostat
-		// crashes the plugin IF there is no value defined (like 
-		// with DOMESTIC_HOT_WATER) so we need to chek if it
-		// is defined first
-		if (this.model = "HeatingZone"){
-			var targetTemperature = this.thermostat.setpointStatus.targetHeatTemperature;
-			that.log("Device type is: " + this.model + ". Target temperature should be there.");
-			that.log("Target temperature for", this.name, "is", targetTemperature + "°");
-		} else {
-			targetTemperature = 0;
-			that.log("Device type is: " + this.model + ". Target temperature is probably NOT there (this is normal).");
-			that.log("Will set target temperature for", this.name, "to " + targetTemperature + "°");
-		}
-		callback(null, Number(targetTemperature));
-
-	},
-
-	getTemperatureDisplayUnits: function(callback) {
-        var that = this;
-		var temperatureUnits = 0;
-
-		switch(this.temperatureUnit) {
-			case "Fahrenheit":
-				temperatureUnits = 1;
-				break;
-			case "Celsius":
-				temperatureUnits = 0;
-				break;
-			default:
-				temperatureUnits = 0;
-		}
-
-		callback(null, Number(temperatureUnits));
-	},
-
-	setTemperatureDisplayUnits: function(value, callback) {
-		var that = this;
-
-		that.log("set temperature units to", value);
-		callback();
-	},
-
-    getServices: function() {
-        var that = this;
-
-        // Information Service
-        var informationService = new Service.AccessoryInformation();
-
-        informationService
-        	.setCharacteristic(Characteristic.Identify, this.name)
-        	.setCharacteristic(Characteristic.Manufacturer, "Honeywell")
-        	.setCharacteristic(Characteristic.Model, this.model)
-        	.setCharacteristic(Characteristic.Name, this.name)
-        	.setCharacteristic(Characteristic.SerialNumber, "123456"); // need to stringify the this.serial
-
-        // Thermostat Service
-        //this.thermostatService = new Service.Thermostat("Honeywell Thermostat");
-	// Remove the old way above because it creates all devices as "Honeywell Thermostat" so I have no idea which thermostat it is.
-	// This new way creates each thermostat as its own room name, as pulled from Evohome
-	this.thermostatService = new Service.Thermostat(this.name);
-
-		// Required Characteristics /////////////////////////////////////////////////////////////
-  		// this.addCharacteristic(Characteristic.CurrentHeatingCoolingState); READ
-  		this.thermostatService
-        	.getCharacteristic(Characteristic.CurrentHeatingCoolingState)
-        		.on('get', this.getCurrentHeatingCoolingState.bind(this));
-
-  		// this.addCharacteristic(Characteristic.TargetHeatingCoolingState); READ WRITE
-  		this.thermostatService
-  			.getCharacteristic(Characteristic.TargetHeatingCoolingState)
-  			.on('get', this.getTargetHeatingCooling.bind(this))
-  			.on('set', this.setTargetHeatingCooling.bind(this));
-
-  		// this.addCharacteristic(Characteristic.CurrentTemperature); READ
-  		this.thermostatService
-  			.getCharacteristic(Characteristic.CurrentTemperature)
-  			.on('get', this.getCurrentTemperature.bind(this))
-  			.setProps({
-  			  minValue: 5,
-  			  maxValue: 35,
-  			  minStep: 0.5
-  			});
-
-  		// this.addCharacteristic(Characteristic.TargetTemperature); READ WRITE
-  		this.thermostatService
-  			.getCharacteristic(Characteristic.TargetTemperature)
-  			.on('get', this.getTargetTemperature.bind(this))
-  			.on('set', this.setTargetTemperature.bind(this))
-  			.setProps({
-  			  minValue: 5,
-  			  maxValue: 35,
-  			  minStep: 0.5
-  			});
-
-  		// this.addCharacteristic(Characteristic.TemperatureDisplayUnits); READ WRITE
-  		this.thermostatService
-  			.getCharacteristic(Characteristic.TemperatureDisplayUnits)
-  			.on('get', this.getTemperatureDisplayUnits.bind(this));
-  		
-  		// Optional Characteristics /////////////////////////////////////////////////////////////
-  		// this.addOptionalCharacteristic(Characteristic.CurrentRelativeHumidity);
-  		// this.addOptionalCharacteristic(Characteristic.TargetRelativeHumidity);
-  		// this.addOptionalCharacteristic(Characteristic.CoolingThresholdTemperature);
-  		// this.addOptionalCharacteristic(Characteristic.HeatingThresholdTemperature);
-  		// this.addOptionalCharacteristic(Characteristic.Name);
-
-        return [informationService, this.thermostatService];
-
+        that.log("Device type is: " + this.model + ". Target temperature is probably NOT there (this is normal).");
+        that.log("Will set target temperature for", this.name, "to " + targetTemperature + "°");
     }
+    callback(null, Number(targetTemperature));
+    
+},
+    
+getTemperatureDisplayUnits: function(callback) {
+    var that = this;
+    var temperatureUnits = 0;
+    
+    switch(this.temperatureUnit) {
+        case "Fahrenheit":
+            temperatureUnits = 1;
+            break;
+        case "Celsius":
+            temperatureUnits = 0;
+            break;
+        default:
+            temperatureUnits = 0;
+    }
+    
+    callback(null, Number(temperatureUnits));
+},
+    
+setTemperatureDisplayUnits: function(value, callback) {
+    var that = this;
+    
+    that.log("set temperature units to", value);
+    callback();
+},
+    
+getServices: function() {
+    var that = this;
+    
+    // Information Service
+    var informationService = new Service.AccessoryInformation();
+    
+    informationService
+    .setCharacteristic(Characteristic.Identify, this.name)
+    .setCharacteristic(Characteristic.Manufacturer, "Honeywell")
+    .setCharacteristic(Characteristic.Model, this.model)
+    .setCharacteristic(Characteristic.Name, this.name)
+    .setCharacteristic(Characteristic.SerialNumber, "123456"); // need to stringify the this.serial
+    
+    // Thermostat Service
+    //this.thermostatService = new Service.Thermostat("Honeywell Thermostat");
+    // Remove the old way above because it creates all devices as "Honeywell Thermostat" so I have no idea which thermostat it is.
+    // This new way creates each thermostat as its own room name, as pulled from Evohome
+    this.thermostatService = new Service.Thermostat(this.name);
+    
+    // Required Characteristics /////////////////////////////////////////////////////////////
+    // this.addCharacteristic(Characteristic.CurrentHeatingCoolingState); READ
+    this.thermostatService
+    .getCharacteristic(Characteristic.CurrentHeatingCoolingState)
+    .on('get', this.getCurrentHeatingCoolingState.bind(this));
+    
+    // this.addCharacteristic(Characteristic.TargetHeatingCoolingState); READ WRITE
+    this.thermostatService
+    .getCharacteristic(Characteristic.TargetHeatingCoolingState)
+    .on('get', this.getTargetHeatingCooling.bind(this))
+    .on('set', this.setTargetHeatingCooling.bind(this));
+    
+    // this.addCharacteristic(Characteristic.CurrentTemperature); READ
+    this.thermostatService
+    .getCharacteristic(Characteristic.CurrentTemperature)
+    .on('get', this.getCurrentTemperature.bind(this))
+    .setProps({
+              minValue: 5,
+              maxValue: 35,
+              minStep: 0.5
+              });
+    
+    // this.addCharacteristic(Characteristic.TargetTemperature); READ WRITE
+    this.thermostatService
+    .getCharacteristic(Characteristic.TargetTemperature)
+    .on('get', this.getTargetTemperature.bind(this))
+    .on('set', this.setTargetTemperature.bind(this))
+    .setProps({
+              minValue: 5,
+              maxValue: 35,
+              minStep: 0.5
+              });
+    
+    // this.addCharacteristic(Characteristic.TemperatureDisplayUnits); READ WRITE
+    this.thermostatService
+    .getCharacteristic(Characteristic.TemperatureDisplayUnits)
+    .on('get', this.getTemperatureDisplayUnits.bind(this));
+    
+    // Optional Characteristics /////////////////////////////////////////////////////////////
+    // this.addOptionalCharacteristic(Characteristic.CurrentRelativeHumidity);
+    // this.addOptionalCharacteristic(Characteristic.TargetRelativeHumidity);
+    // this.addOptionalCharacteristic(Characteristic.CoolingThresholdTemperature);
+    // this.addOptionalCharacteristic(Characteristic.HeatingThresholdTemperature);
+    // this.addOptionalCharacteristic(Characteristic.Name);
+    
+    return [informationService, this.thermostatService];
+    
+}
 }

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function(homebridge) {
         this.setProps({
                       format: Characteristic.Formats.UINT8,
                       unit: Characteristic.Units.PERCENTAGE,
-                      perms: [Characteristic.Perms.READ]
+                      perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
                       });
         this.value = this.getDefaultValue();
     };
@@ -41,7 +41,7 @@ module.exports = function(homebridge) {
         Characteristic.call(this, 'Program command', 'E863F12C-079E-48FF-8F27-9C2605A29F52');
         this.setProps({
                       format: Characteristic.Formats.DATA,
-                      perms: [Characteristic.Perms.WRITE]
+                      perms: [Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY]
                       });
         this.value = this.getDefaultValue();
     };
@@ -51,7 +51,7 @@ module.exports = function(homebridge) {
         Characteristic.call(this, 'Program data', 'E863F12F-079E-48FF-8F27-9C2605A29F52');
         this.setProps({
                       format: Characteristic.Formats.DATA,
-                      perms: [Characteristic.Perms.READ]
+                      perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY]
                       });
         this.value = this.getDefaultValue();
     };
@@ -66,7 +66,7 @@ function EvohomePlatform(log, config){
     this.password = config['password'];
     this.temperatureUnit = config['temperatureUnit'];
     
-    this.cache_timeout = 30; // seconds
+    this.cache_timeout = 300; // seconds
     
     this.log = log;
     

--- a/index.js
+++ b/index.js
@@ -234,9 +234,17 @@ EvohomeThermostatAccessory.prototype = {
 	getTargetTemperature: function(callback) {
 		var that = this;
 
-		// just trying this out... shoud give back 128
-		var targetTemperature = this.device.thermostat.changeableValues.heatSetpoint['value'];
-		that.log("Target temperature for", this.name, "is", targetTemperature + "°");
+		// gives back the target temperature of thermostat
+		// crashes the plugin IF there is no value defined (like 
+		// with DOMESTIC_HOT_WATER) so we need to chek if it
+		// is defined first
+		if (this.device.thermostat.changeableValues.heatSetpoint['value']){
+			var targetTemperature = this.device.thermostat.changeableValues.heatSetpoint['value'];
+			that.log("Target temperature for", this.name, "is", targetTemperature + "°");
+		} else {
+			var targetTemperature = 0;
+			that.log("Target temperature is not defined. Perhaps the device does not supprot this value. Set target temperature to 0°");
+		}
 		callback(null, Number(targetTemperature));
 
 	},

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function EvohomePlatform(log, config){
     this.minTemp = config['minTemp'] || 15.0;
     this.maxTemp = config['maxTemp'] || 25.0;
     
-    this.cache_timeout = 10;//890; // seconds
+    this.cache_timeout = 890; // seconds
 
 	this.log = log;
     

--- a/index.js
+++ b/index.js
@@ -115,18 +115,21 @@ EvohomePlatform.prototype.periodicUpdate = function(session,myAccessories) {
                                         
                         if(oldCurrentTemp!=newCurrentTemp && service) {
                             this.log("Updating: " + device.name + " currentTempChange from: " + oldCurrentTemp + " to: " + newCurrentTemp);
-                            service.getCharacteristic(Characteristic.CurrentTemperature)
-                                        .getValue();
+                            var charCT = service.getCharacteristic(Characteristic.CurrentTemperature);
+                            if(charCT) charCT.setValue(newCurrentTemp);
+                            else this.log("No Characteristic.CurrentTemperature found " + service);
                         }
                                         
-                        var oldTargetTemp = this.myAccessories[i].device.thermostat.changeableValues.heatSetpoint['value'];     
+                        var oldTargetTemp = this.myAccessories[i].device.thermostat.changeableValues.heatSetpoint['value'];
                         var newTargetTemp = device.thermostat.changeableValues.heatSetpoint['value'];
                                         
                         if(oldTargetTemp!=newTargetTemp && service) {
                             this.log("Updating: " + device.name + " targetTempChange from: " + oldTargetTemp + " to: " + newTargetTemp);
-                            service.getCharacteristic(Characteristic.TargetTemperature)
-                                        .getValue();
-                        }                        
+                            var charTT = service.getCharacteristic(Characteristic.TargetTemperature);
+                            if(charTT) charCT.setValue(newTargetTemp);
+                            else this.log("No Characteristic.TargetTemperature found " + service);
+                        }
+                        this.myAccessories[i].device = device;
                     }
                 }
             }.bind(this)).fail(function(err){

--- a/index.js
+++ b/index.js
@@ -57,15 +57,17 @@ EvohomePlatform.prototype = {
 				for (var deviceId in locations[0].devices) {
 					// print name of the device
 					this.log(deviceId + ": " + locations[0].devices[deviceId].name + " (" + locations[0].devices[deviceId].thermostat.indoorTemperature + "°)");
-					
+
 					// store device in var
 					var device = locations[0].devices[deviceId];
 					// store name of device
 					var name = locations[0].devices[deviceId].name + " Thermostat";
-					// create accessory
-					var accessory = new EvohomeThermostatAccessory(that.log, name, device, deviceId, this.username, this.password, this.appId);
-					// store accessory in myAccessories
-					this.myAccessories.push(accessory);
+					// create accessory (only if it is "EMEA_ZONE")
+					if (device.thermostatModelType = "EMEA_ZONE") {
+						var accessory = new EvohomeThermostatAccessory(that.log, name, device, deviceId, this.username, this.password, this.appId);
+						// store accessory in myAccessories
+						this.myAccessories.push(accessory);
+					}
 				}
 
 				callback(this.myAccessories);

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ var Service, Characteristic;
 var config;
 var FakeGatoHistoryService;
 var inherits = require('util').inherits;
+const moment = require('moment');
 var CustomCharacteristic = {};
 
 module.exports = function(homebridge) {
@@ -65,7 +66,7 @@ function EvohomePlatform(log, config){
     this.password = config['password'];
     this.temperatureUnit = config['temperatureUnit'];
     
-    this.cache_timeout = 300; // seconds
+    this.cache_timeout = 30; // seconds
     
     this.log = log;
     
@@ -183,8 +184,10 @@ EvohomePlatform.prototype.periodicUpdate = function(session,myAccessories) {
                                                 this.myAccessories[i].thermostat = thermostat;
                                                                      
                                                 var loggingService = this.myAccessories[i].loggingService;
-                                                                     
-                                                loggingService.addEntry({time: moment().unix(), currentTemp:newCurrentTemp, setTemp:newTargetTemp, valvePosition:50}); // valve pos 50%???
+                                                
+                                                //this.log("populating loggingService: " + loggingService);
+                                                //this.log(moment().unix() + " " + newCurrentTemp + " " + newTargetTemp);
+                                                loggingService.addEntry({time:moment().unix(), currentTemp:newCurrentTemp, setTemp:newTargetTemp, valvePosition:50}); // valve pos 50%???
                                             }
                                                                                                                                           
                                         }
@@ -213,7 +216,7 @@ function EvohomeThermostatAccessory(log, name, device, deviceId, thermostat, tem
     this.displayName = name; // fakegato
     this.device = device;
     this.model = device.modelType;
-    this.serial = device.deviceID;
+    this.serial = deviceId;
     this.deviceId = deviceId;
     
     this.thermostat = thermostat;
@@ -398,12 +401,15 @@ getServices: function() {
     // Information Service
     var informationService = new Service.AccessoryInformation();
     
+    //var serial = 123456 + this.deviceId;
+    var strSerial = this.serial.toString();
+    
     informationService
     .setCharacteristic(Characteristic.Identify, this.name)
     .setCharacteristic(Characteristic.Manufacturer, "Honeywell")
     .setCharacteristic(Characteristic.Model, this.model)
     .setCharacteristic(Characteristic.Name, this.name)
-    .setCharacteristic(Characteristic.SerialNumber, "123456"); // need to stringify the this.serial
+    .setCharacteristic(Characteristic.SerialNumber, strSerial); // need to stringify the this.serial
     
     // Thermostat Service
     //this.thermostatService = new Service.Thermostat("Honeywell Thermostat");

--- a/index.js
+++ b/index.js
@@ -107,9 +107,8 @@ EvohomePlatform.prototype.periodicUpdate = function(session,myAccessories) {
                                         
                         if(oldCurrentTemp!=newCurrentTemp && service) {
                             this.log("Updating: " + device.name + " currentTempChange from: " + oldCurrentTemp + " to: " + newCurrentTemp);
-                            var charCT = service.getCharacteristic(Characteristic.CurrentTemperature);
-                            if(charCT) charCT.setValue(newCurrentTemp);
-                            else this.log("No Characteristic.CurrentTemperature found " + service);
+                            service.getCharacteristic(Characteristic.CurrentTemperature)
+                                        .getValue();
                         }
                                         
                         var oldTargetTemp = this.myAccessories[i].device.thermostat.changeableValues.heatSetpoint['value'];     
@@ -117,12 +116,9 @@ EvohomePlatform.prototype.periodicUpdate = function(session,myAccessories) {
                                         
                         if(oldTargetTemp!=newTargetTemp && service) {
                             this.log("Updating: " + device.name + " targetTempChange from: " + oldTargetTemp + " to: " + newTargetTemp);
-                            var charTT = service.getCharacteristic(Characteristic.TargetTemperature);
-                            if(charTT) charCT.setValue(newTargetTemp);
-                            else this.log("No Characteristic.TargetTemperature found " + service);
-                        }
-                        
-                        this.myAccessories[i].device = device;
+                            service.getCharacteristic(Characteristic.TargetTemperature)
+                                        .getValue();
+                        }                        
                     }
                 }
             }.bind(this)).fail(function(err){

--- a/index.js
+++ b/index.js
@@ -238,12 +238,14 @@ EvohomeThermostatAccessory.prototype = {
 		// crashes the plugin IF there is no value defined (like 
 		// with DOMESTIC_HOT_WATER) so we need to chek if it
 		// is defined first
-		if (this.device.thermostat.changeableValues.heatSetpoint['value']){
+		if (this.model = "EMEA_ZONE"){
 			var targetTemperature = this.device.thermostat.changeableValues.heatSetpoint['value'];
+			that.log("Device type is:", this.model, ". Target temperature should be there.")
 			that.log("Target temperature for", this.name, "is", targetTemperature + "°");
 		} else {
 			var targetTemperature = 0;
-			that.log("Target temperature is not defined. Perhaps the device does not supprot this value. Set target temperature to 0°");
+			that.log("Device type is:", this.model, ". Target temperature is probably not there.")
+			that.log("Will set target temperature for", this.name, "to " + targetTemperature + "°");
 		}
 		callback(null, Number(targetTemperature));
 

--- a/index.js
+++ b/index.js
@@ -240,11 +240,11 @@ EvohomeThermostatAccessory.prototype = {
 		// is defined first
 		if (this.model = "EMEA_ZONE"){
 			var targetTemperature = this.device.thermostat.changeableValues.heatSetpoint['value'];
-			that.log("Device type is:", this.model, ". Target temperature should be there.")
+			that.log("Device type is:", this.model, ". Target temperature should be there.");
 			that.log("Target temperature for", this.name, "is", targetTemperature + "°");
 		} else {
 			var targetTemperature = 0;
-			that.log("Device type is:", this.model, ". Target temperature is probably not there.")
+			that.log("Device type is:", this.model, ". Target temperature is probably not there.");
 			that.log("Will set target temperature for", this.name, "to " + targetTemperature + "°");
 		}
 		callback(null, Number(targetTemperature));

--- a/index.js
+++ b/index.js
@@ -323,7 +323,8 @@ EvohomeThermostatAccessory.prototype = {
   			.getCharacteristic(Characteristic.CurrentTemperature)
   			.on('get', this.getCurrentTemperature.bind(this));
 	    	
-	    	this.Characteristic.CurrentTemperature.minimumValue = 0;
+        this.thermostatService
+            .getCharacteristic(Characteristic.CurrentTemperature).minimumValue = 0;
 
   		// this.addCharacteristic(Characteristic.TargetTemperature); READ WRITE
   		this.thermostatService
@@ -331,7 +332,8 @@ EvohomeThermostatAccessory.prototype = {
   			.on('get', this.getTargetTemperature.bind(this))
   			.on('set', this.setTargetTemperature.bind(this));
 	    
-	    	this.Characteristic.TargetTemperature.minimumValue = 0;
+        this.thermostatService
+            .getCharacteristic(Characteristic.TargetTemperature).minimumValue = 0;
 
   		// this.addCharacteristic(Characteristic.TemperatureDisplayUnits); READ WRITE
   		this.thermostatService

--- a/index.js
+++ b/index.js
@@ -240,11 +240,11 @@ EvohomeThermostatAccessory.prototype = {
 		// is defined first
 		if (this.model = "EMEA_ZONE"){
 			var targetTemperature = this.device.thermostat.changeableValues.heatSetpoint['value'];
-			that.log("Device type is:", this.model, ". Target temperature should be there.");
+			that.log("Device type is: " + this.model + ". Target temperature should be there.");
 			that.log("Target temperature for", this.name, "is", targetTemperature + "°");
 		} else {
 			var targetTemperature = 0;
-			that.log("Device type is:", this.model, ". Target temperature is probably not there.");
+			that.log("Device type is: " + this.model + ". Target temperature is probably NOT there (this is normal).");
 			that.log("Will set target temperature for", this.name, "to " + targetTemperature + "°");
 		}
 		callback(null, Number(targetTemperature));

--- a/lib/evohome.js
+++ b/lib/evohome.js
@@ -178,7 +178,11 @@ function login(username, password, appId) {
 		if(err) {
 			deferred.reject(err);
 		} else {
-			deferred.resolve(JSON.parse(response.body));
+            try {
+                deferred.resolve(JSON.parse(response.body));
+            } catch (e) {
+                deferred.reject(e);
+            }
 		}
 	});
 	return deferred.promise;

--- a/lib/evohome.js
+++ b/lib/evohome.js
@@ -74,7 +74,7 @@ function Thermostat(json) {
 }
 
 Session.prototype.getLocations = function() {
-	var url = "https://rs.alarmnet.com/TotalConnectComfort/WebAPI/api/locations?userId=" + this.userInfo.userID + "&allData=True";
+	var url = "https://tccna.honeywell.com/WebAPI/api/locations?userId=" + this.userInfo.userID + "&allData=True";
 	return this._request(url).then(function(json) {
 		return _.map(json, function(location) {
 			return new Location(location);
@@ -86,7 +86,7 @@ Session.prototype.getLocations = function() {
 
 Session.prototype.setHeatSetpoint = function (deviceId, targetTemperature, minutes) {
     var deferred = Q.defer();
-    var url = "https://rs.alarmnet.com/TotalConnectComfort/WebAPI/api/devices/" + deviceId + "/thermostat/changeableValues/heatSetpoint";
+    var url = "https://tccna.honeywell.com/WebAPI/api/devices/" + deviceId + "/thermostat/changeableValues/heatSetpoint";
     var now = new Date();
     var timezoneOffsetInMinutes = now.getTimezoneOffset();
     
@@ -165,7 +165,7 @@ function login(username, password, appId) {
 	var deferred = Q.defer();
 	request({
 		method: 'POST',
-		url: 'https://rs.alarmnet.com/TotalConnectComfort/WebAPI/api/Session',
+		url: 'https://tccna.honeywell.com/WebAPI/api/Session',
 		headers: {
 			'Content-Type': 'application/json'
 		},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-evohome",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Honeywell Evohome support for Homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "lodash": "~2.4.1",
     "q": "~1.0.1",
-    "request": "~2.34.0"
+    "request": "~2.34.0",
+    "fakegato-history": "^0.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-evohome",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Honeywell Evohome support for Homebridge: https://github.com/nfarina/homebridge",
   "license": "ISC",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,60 +1,28 @@
 {
-  "_args": [
-    [
-      "git+https://git@github.com/luc-ass/homebridge-evohome",
-      ""
-    ]
+  "name": "homebridge-evohome",
+  "version": "0.1.2",
+  "description": "Honeywell Evohome support for Homebridge: https://github.com/nfarina/homebridge",
+  "license": "ISC",
+  "keywords": [
+    "homebridge-plugin",
+    "evohome",
+    "honeywell"
   ],
-  "_from": "git+https://git@github.com/luc-ass/homebridge-evohome.git",
-  "_id": "homebridge-evohome@0.0.1",
-  "_inCache": true,
-  "_installable": true,
-  "_location": "/homebridge-evohome",
-  "_phantomChildren": {},
-  "_requested": {
-    "hosted": {
-      "directUrl": "https://git@raw.githubusercontent.com/luc-ass/homebridge-evohome/master/package.json",
-      "gitUrl": "git://git@github.com/luc-ass/homebridge-evohome.git",
-      "httpsUrl": "git+https://git@github.com/luc-ass/homebridge-evohome.git",
-      "shortcut": "github:luc-ass/homebridge-evohome",
-      "ssh": "git@github.com:luc-ass/homebridge-evohome.git",
-      "sshUrl": "git+ssh://git@github.com/luc-ass/homebridge-evohome.git",
-      "type": "github"
-    },
-    "name": null,
-    "raw": "git+https://git@github.com/luc-ass/homebridge-evohome",
-    "rawSpec": "git+https://git@github.com/luc-ass/homebridge-evohome",
-    "scope": null,
-    "spec": "git+https://git@github.com/luc-ass/homebridge-evohome.git",
-    "type": "hosted"
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/luc-ass/homebridge-evohome.git"
   },
-  "_requiredBy": [
-    "#USER"
-  ],
-  "_resolved": "git+https://git@github.com/luc-ass/homebridge-evohome.git#a2c797a302f0b03ab8b4df70c02032afa847f7dc",
-  "_shasum": "d2244317e48e44a59f1125928061a07ee4538178",
-  "_shrinkwrap": null,
-  "_spec": "git+https://git@github.com/luc-ass/homebridge-evohome",
-  "_where": "",
+  "bugs": {
+    "url": "http://github.com/luc-ass/homebridge-evohome/issues"
+  },
+  "engines": {
+    "node": ">=0.12.0",
+    "homebridge": ">=0.3.1"
+  },
   "dependencies": {
     "lodash": "~2.4.1",
     "q": "~1.0.1",
     "request": "~2.34.0"
-  },
-  "description": "Evohome plugin for homebridge: https://github.com/luc-ass/homebridge-evohome",
-  "devDependencies": {},
-  "engines": {
-    "homebridge": ">=0.2.0",
-    "node": ">=0.12.0"
-  },
-  "gitHead": "a2c797a302f0b03ab8b4df70c02032afa847f7dc",
-  "keywords": [
-    "homebridge-plugin"
-  ],
-  "license": "ISC",
-  "name": "homebridge-evohome",
-  "optionalDependencies": {},
-  "readme": "# homebridge-evohome\n\nThis ia a plugin for Honeywell evohome. It is a partially-working implementation into HomeKit. This plugin is work in progress. Help is appreciated!\n\n# Installation\n\nThis plugin is not yet on NPM. Insatllation only via GitHub at the moment...\n\n1. Install homebridge using: npm install -g homebridge <br>\n2. Install this plugin using npm install -g git+https://git@github.com/luc-ass/homebridge-evohome\n3. Update your configuration file. See sample-config below for a sample. \n\n# Configuration\n\nConfiguration sample:\n\n```\n\"platform\": [\n        {\n            \"platform\": \"Evohome\",\n            \"name\" : \"Evohome\",\n            \"username\" : \"username/email\",\n            \"password\" : \"password\",\n            \"appId\" : \"91db1612-73fd-4500-91b2-e63b069b185c\"\n        }\n    ]\n```\n\n- platform: Evohome\n- name: can be anything you want\n- username: your Honeywell e-mail\n- password: your Honeywell password\n- appId: \"91db1612-73fd-4500-91b2-e63b069b185c\" no need to change this\n\n# Roadmap\n\n- ~~get temperature~~\n- ~~update temperature~~\n- ~~get device name~~\n- set target temperature\n",
-  "readmeFilename": "README.md",
-  "version": "0.1.1"
+  }
 }
+

--- a/package.json
+++ b/package.json
@@ -56,5 +56,5 @@
   "optionalDependencies": {},
   "readme": "# homebridge-evohome\n\nThis ia a plugin for Honeywell evohome. It is a partially-working implementation into HomeKit. This plugin is work in progress. Help is appreciated!\n\n# Installation\n\nThis plugin is not yet on NPM. Insatllation only via GitHub at the moment...\n\n1. Install homebridge using: npm install -g homebridge <br>\n2. Install this plugin using npm install -g git+https://git@github.com/luc-ass/homebridge-evohome\n3. Update your configuration file. See sample-config below for a sample. \n\n# Configuration\n\nConfiguration sample:\n\n```\n\"platform\": [\n        {\n            \"platform\": \"Evohome\",\n            \"name\" : \"Evohome\",\n            \"username\" : \"username/email\",\n            \"password\" : \"password\",\n            \"appId\" : \"91db1612-73fd-4500-91b2-e63b069b185c\"\n        }\n    ]\n```\n\n- platform: Evohome\n- name: can be anything you want\n- username: your Honeywell e-mail\n- password: your Honeywell password\n- appId: \"91db1612-73fd-4500-91b2-e63b069b185c\" no need to change this\n\n# Roadmap\n\n- ~~get temperature~~\n- ~~update temperature~~\n- ~~get device name~~\n- set target temperature\n",
   "readmeFilename": "README.md",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lodash": "~2.4.1",
     "q": "~1.0.1",
     "request": "~2.34.0",
-    "fakegato-history": "^0.3.4"
+    "fakegato-history": "^0.3.4",
+    "moment": "^2.18.1"
   }
 }


### PR DESCRIPTION
This should include graphs for current and target temperature when using Elgato's Eve app.

Thanks to: https://github.com/simont77/fakegato-history 

Note: You may need to restart the app to show to graphs and perhaps drag down to refresh with new data. Also, I've changed the accessory serials which only show when you remove and re-add the plugin to homekit (not sure if this is absolutely necessary)