### PR TITLE
Enable the functionality to turn off heating per zone in Homekit

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ EvohomePlatform.prototype = {
     }
 };
 
-EvohomePlatform.prototype.renewSession = function(session,myAccessories) {
+EvohomePlatform.prototype.renewSession = function() {
     var that = this;
     var session = this.sessionObject;
     session._renew().then(function(json) {
@@ -185,7 +185,7 @@ EvohomePlatform.prototype.renewSession = function(session,myAccessories) {
     });
 }
 
-EvohomePlatform.prototype.periodicUpdate = function(session,myAccessories) {
+EvohomePlatform.prototype.periodicUpdate = function() {
     
     if(!this.updating && this.myAccessories){
         this.updating = true;
@@ -393,8 +393,6 @@ EvohomeThermostatAccessory.prototype = {
                     that.targetTemperateToSet = -1;
                     that.thermostat.setpointStatus.targetHeatTemperature = value;
                     // set target temperature here also to prevent from setting temperature two times
-                    // nothing else here...
-                    //callback(null, Number(1));
                 });
             }).fail(function(err) {
                 that.log('Evohome failed:', err);
@@ -416,15 +414,18 @@ EvohomeThermostatAccessory.prototype = {
     getCurrentHeatingCoolingState: function(callback) {
         var that = this;
 
-        that.log("getCurrentHeatingCooling");
-
-        // TODO:
-        // fixed until it can be requested from Evohome...
         // OFF  = 0
         // HEAT = 1
         // COOL = 2
         // AUTO = 3
-        callback(null, Number(1));
+        if (this.model == "HeatingZone"){
+            var targetTemp = this.thermostat.setpointStatus.targetHeatTemperature;
+            var state = (targetTemp == 5) ? 0 : 1;
+        } else {
+            var state = 1;
+            // domestic hot water not supported (set to heat by default)
+        }
+        callback(null, Number(state));
 
     },
 
@@ -440,24 +441,45 @@ EvohomeThermostatAccessory.prototype = {
 
     setTargetHeatingCooling: function(value, callback) {
         var that = this;
+        var session = that.platform.sessionObject;
 
-        // not implemented 
+        if(value == 0) {
+            // set temperature to 5 degrees permanently when heating is "off"
+            session.setHeatSetpoint(that.device.zoneID, 5, null).then(function (taskId) {
+                that.log("Heating is set off for " + that.name + " (set to 5°)");
+                that.log(taskId);
+                // returns taskId if successful
+                that.thermostat.setpointStatus.targetHeatTemperature = 5;
+                // set target temperature here also to prevent from setting temperature two times
+            });
+        } else {
+            // set thermostat to follow the schedule by passing 0 to the method
+            session.setHeatSetpoint(that.device.zoneID, 0, null).then(function (taskId) {
+                that.log("Cancelled override for " + that.name + " (set to follow schedule)");
+                that.log(taskId);
+                // returns taskId if successful
+            });
+        }
 
-        that.log("attempted to change targetHeatingCooling: " + value +" - not yet implemented");
-        callback();
+        callback(null);
 
     },
 
     getTargetHeatingCooling: function(callback) {
         var that = this;
 
-        // TODO:
-        // fixed until it can be requested from Evohome...
         // OFF  = 0
         // HEAT = 1
         // COOL = 2
         // AUTO = 3
-        callback(null, Number(1));
+        if (this.model == "HeatingZone"){
+            var targetTemp = this.thermostat.setpointStatus.targetHeatTemperature;
+            var state = (targetTemp == 5) ? 0 : 1;
+        } else {
+            var state = 1;
+            // domestic hot water not supported (set to heat by default)
+        }
+        callback(null, Number(state));
 
     },
 
@@ -651,6 +673,11 @@ EvohomeSwitchAccessory.prototype = {
             if(taskId.id != null) {
                 that.log("System mode is set to: " + systemMode);
                 that.log(taskId);
+
+                // force update to get newest values from Honeywell with delay of 3 seconds (else it's too fast)
+                setTimeout(function() {
+                    that.platform.periodicUpdate();
+                }, 3 * 1000);
 
                 that.active = value;
                 callback(null, Number(1));

--- a/lib/evohome.js
+++ b/lib/evohome.js
@@ -146,13 +146,22 @@ Session.prototype.setHeatSetpoint = function (zoneId, targetTemperature, endtime
     var url = "https://tccna.honeywell.com/WebAPI/emea/api/v1/temperatureZone/" + zoneId + "/heatSetpoint";
     var now = new Date();
     
-    if(endtime == "00:00:00") {
-        now.setDate(now.getDate() + 1);
+    if(endtime != null) {
+        if(endtime == "00:00:00") {
+            now.setDate(now.getDate() + 1);
+        }
+        var endDateString = now.toDateString() + " " + endtime;
+        var endDate = new Date(Date.parse(endDateString));
+
+        var body = JSON.stringify({"HeatSetpointValue":targetTemperature,"SetpointMode":"TemporaryOverride","TimeUntil":endDate});
+    } else {
+        // if target temperature is set to zero then we ask to follow the schedule instead of setting a temperature
+        if(targetTemperature == 0) {
+            var body = JSON.stringify({"HeatSetpointValue":0.0,"SetpointMode":"FollowSchedule","TimeUntil":null});
+        } else {
+            var body = JSON.stringify({"HeatSetpointValue":targetTemperature,"SetpointMode":"PermanentOverride","TimeUntil":null});
+        }
     }
-    var endDateString = now.toDateString() + " " + endtime;
-    var endDate = new Date(Date.parse(endDateString));
-    
-    var body = JSON.stringify({"HeatSetpointValue":targetTemperature,"SetpointMode":"TemporaryOverride","TimeUntil":endDate});
     
     request({
             method: 'PUT',


### PR DESCRIPTION
This one enables the functionality to turn off heating per zone in Homekit.
Currently if you put a zone to off then it will set the temperature to 5°C permanently (not until next scheduled change).
When you turn on the heating again for a zone it cancels the override for that zone, so it will follow the schedule again.