### PR TITLE
Set min and max temperature per zone as set on Evohome controller

### DIFF
--- a/index.js
+++ b/index.js
@@ -596,9 +596,9 @@ EvohomeThermostatAccessory.prototype = {
         .getCharacteristic(Characteristic.CurrentTemperature)
         .on('get', this.getCurrentTemperature.bind(this))
         .setProps({
-                  minValue: 5,
-                  maxValue: 35,
-                  minStep: 0.5
+                    minValue: this.device.minHeatSetpoint,
+                    maxValue: this.device.maxHeatSetpoint,
+                    minStep: this.device.valueResolution
                   });
 
         // this.addCharacteristic(Characteristic.TargetTemperature); READ WRITE
@@ -607,9 +607,9 @@ EvohomeThermostatAccessory.prototype = {
         .on('get', this.getTargetTemperature.bind(this))
         .on('set', this.setTargetTemperature.bind(this))
         .setProps({
-                  minValue: 5,
-                  maxValue: 35,
-                  minStep: 0.5
+                    minValue: this.device.minHeatSetpoint,
+                    maxValue: this.device.maxHeatSetpoint,
+                    minStep: this.device.valueResolution
                   });
 
         // this.addCharacteristic(Characteristic.TemperatureDisplayUnits); READ WRITE

--- a/lib/evohome.js
+++ b/lib/evohome.js
@@ -57,6 +57,9 @@ function Device(json) {
     this.zoneType = json.zoneType;
     this.modelType = json.modelType;
     this.name = json.name;
+    this.maxHeatSetpoint = json.setpointCapabilities.maxHeatSetpoint;
+    this.minHeatSetpoint = json.setpointCapabilities.minHeatSetpoint;
+    this.valueResolution = json.setpointCapabilities.valueResolution;
 }
 
 function Thermostat(json) {


### PR DESCRIPTION
Set min and max temperature per zone to the same values that are set on the Evohome controller
Homebridge needs to be restarted each time when you change the min and max temperatures on the Evohome controller (tried but not possible to update this characteristic while it's running).
Fixes this one: #37 