### PR TITLE
Currenttime fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Configuration sample:
 - Your password may not contain `&` or else the login will fail.
 - Updating from `<0.5.1` to `>0.6.0` will create new devices and put them into the standard room of your home. They just need to be moved back to their rooms. This is expected behaviour as the UUID has changed. Historic data will be retained. This can also happen without a clear cause. It is under investigation here: [#61](../../issues/61).
 
-## 💥 Beta Testing
+## 🧪 Beta Testing
 
 This part talks about testing pre-release version of the plugin. I strongly recommend, that you don't do this in your production environment. It will frequently reset accessories and break automations. If you still want to or have been asked to, this is my preferred way of installing from github:
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ rm -r homebridge-evohome
 # recreate the folder
 mkdir homebridge-evohome
 # clone repo to folder
-git clone https://github.com/luc-ass/homebridge-evohome.git ./homebridge-evohome
+git clone --branch main https://github.com/luc-ass/homebridge-evohome.git ./homebridge-evohome
 # cd into folder
 cd homebridge-evohome
 # install plugin

--- a/index.js
+++ b/index.js
@@ -698,8 +698,7 @@ EvohomeThermostatAccessory.prototype = {
           weekday[5] = "Friday";
           weekday[6] = "Saturday";
 
-          var currenttime = correctDate.toLocaleTimeString("de-DE", {
-            timeZone: "Europe/Berlin",
+          var currenttime = correctDate.toLocaleTimeString([], {
             hour12: false,
           });
           that.log("The current time is", currenttime);


### PR DESCRIPTION
This fix removes locale and timezone from the plugin. It will default to the timezone and locale set on the system. Only `hours12: false` is kept to allow comparison with data from the evohome api.

Test 1:
```log 
[8/22/2022, 6:28:01 PM] [Evohome] The current time is 18:28:01
[8/22/2022, 6:28:01 PM] [Evohome] Schedule points for today (Monday)
[8/22/2022, 6:28:01 PM] [Evohome] - 06:20:00
[8/22/2022, 6:28:01 PM] [Evohome] - 16:00:00
[8/22/2022, 6:28:01 PM] [Evohome] - 23:30:00 -> next change
[8/22/2022, 6:28:01 PM] [Evohome] Setting target temperature for Wohnküche Thermostat to 20° until 23:30:00
[8/22/2022, 6:28:01 PM] [Evohome] Successfully changed temperature!
[8/22/2022, 6:28:01 PM] [Evohome] { id: '67412699' }
```

Test 2:
`date` returns the same time and format on host and inside homebridge docker-container