### PR TITLE
Make heating mode representation configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Configuration sample:
 | `switchEco`        | yes      | `true`,  `false`                   | creates a switch for eco settings |
 | `switchHeatingOff` | yes      | `true`,  `false`                   | creates a switch to tur off the heating |
 | `switchCustom`     | yes      | `true`,  `false`                   | creates a switch for your custom mode |
+| `temperatureAboveAsOff`     | yes      | `true`,  `false`                   | allows you to displays thermostats as off, if room temperature is above target temperature |
 
 
 ## 📝 Roadmap

--- a/config.schema.json
+++ b/config.schema.json
@@ -73,6 +73,12 @@
 				"type": "boolean",
 				"default": true,
 				"required": false
+			},
+			"temperatureAboveAsOff": {
+				"title": "Represent room temperature above set temperature as off",
+				"type": "boolean",
+				"default": false,
+				"required": true
 			}
 		}
 	},
@@ -101,7 +107,8 @@
 				"switchDayOff",
 				"switchEco",
 				"switchHeatingOff",
-				"switchCustom"
+				"switchCustom",
+				"temperatureAboveAsOff"
 			]
 		}
 	]

--- a/index.js
+++ b/index.js
@@ -87,6 +87,7 @@ function EvohomePlatform(log, config) {
   this.switchEco = config["switchEco"];
   this.switchHeatingOff = config["switchHeatingOff"];
   this.switchCustom = config["switchCustom"];
+  this.temperatureAboveAsOff = config["temperatureAboveAsOff"];
 
   this.cache_timeout = 300; // seconds
   this.interval_setTemperature = 5; // seconds
@@ -890,8 +891,12 @@ EvohomeThermostatAccessory.prototype = {
       var currentTemp = this.thermostat.temperatureStatus.temperature;
 
       // Sets the heating state of the thermostat to either OFF or HEAT
-      // based on the user's desired temperature
-      var state = (targetTemp <= 5 || targetTemp <= currentTemp) ? 0 : 1;
+      var state = (
+        // OFF if targetTemp <= 5 °C
+        targetTemp <= 5 || 
+        // OFF if targetTemp below currentTemp AND 'temperatureAboveAsOff' set to true
+        (targetTemp <= currentTemp && temperatureAboveAsOff )
+        ) ? 0 : 1;
 
     } else {
       var state = 1;


### PR DESCRIPTION
This allows you to choose between two types of "heating representations":
1) Standard:
Thermostats display "off" if the targetTemp is set to 5 °C or lower, otherwise "on".
2) Option:
Thermostats display "off" if the targetTemp is set to 5 °C or lower or targetTemp is lower than currentTemp, otherwise "on".