### PR TITLE
Allow for persistent accessories inside child bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Configuration sample:
 | `switchEco`        | yes      | `true`,  `false`                   | creates a switch for eco settings |
 | `switchHeatingOff` | yes      | `true`,  `false`                   | creates a switch to tur off the heating |
 | `switchCustom`     | yes      | `true`,  `false`                   | creates a switch for your custom mode |
+| `childBridge`     | yes      | `true`,  `false`                   | allows you to have persistent accessories, if plugin is run inside a child bridge |
 
 
 ## 📝 Roadmap

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ rm -r homebridge-evohome
 # recreate the folder
 mkdir homebridge-evohome
 # clone repo to folder
-git clone --branch main https://github.com/luc-ass/homebridge-evohome.git ./homebridge-evohome
+git clone --single-branch --branch main https://github.com/luc-ass/homebridge-evohome.git ./homebridge-evohome
 # cd into folder
 cd homebridge-evohome
 # install plugin

--- a/config.schema.json
+++ b/config.schema.json
@@ -73,6 +73,13 @@
 				"type": "boolean",
 				"default": true,
 				"required": false
+			},
+			"childBridge": {
+				"title": "This accessory runs in a child bridge (recommended)",
+				"description": "This switch should be turned on if the platform is run as a child bridge. This ensures, that accessories are not lost on error.",
+				"type": "boolean",
+				"default": false,
+				"required": false
 			}
 		}
 	},
@@ -101,7 +108,8 @@
 				"switchDayOff",
 				"switchEco",
 				"switchHeatingOff",
-				"switchCustom"
+				"switchCustom",
+				"childBridge"
 			]
 		}
 	]

--- a/config.schema.json
+++ b/config.schema.json
@@ -76,7 +76,7 @@
 			},
 			"childBridge": {
 				"title": "This accessory runs in a child bridge (recommended)",
-				"description": "This switch should be turned on if the platform is run as a child bridge. This ensures, that accessories are not lost on error.",
+				"description": "This switch should be turned on, if the platform is run as a child bridge. This ensures, that accessories are not lost on error.",
 				"type": "boolean",
 				"default": false,
 				"required": false

--- a/config.schema.json
+++ b/config.schema.json
@@ -2,7 +2,7 @@
 	"pluginAlias": "Evohome",
 	"pluginType": "platform",
 	"singular": false,
-	"headerDisplay": "This Plugin integrates your Honeywell Evohome into Homebridge. Please use your credentials from https://getconnected.honeywellhome.com",
+	"headerDisplay": "This Plugin integrates your Honeywell Evohome into Homebridge. Please use your credentials from https://getconnected.honeywellhome.com. You should consider running this plugin as a child bridge, as it allows for persistent accessories, thus prevent breaking your automations!",
 	"footerDisplay": "It is important, that your Homebridge time zone is set correct. Please double check this! If you encounter any problems don't hesitate to have a look at https://github.com/luc-ass/homebridge-evohome.",
 	"schema": {
 		"type": "object",

--- a/index.js
+++ b/index.js
@@ -88,6 +88,8 @@ function EvohomePlatform(log, config) {
   this.switchHeatingOff = config["switchHeatingOff"];
   this.switchCustom = config["switchCustom"];
 
+  this.childBridge = config["childBridge"] || false;
+
   this.cache_timeout = 300; // seconds
   this.interval_setTemperature = 5; // seconds
 
@@ -311,22 +313,34 @@ EvohomePlatform.prototype = {
                         )
                         .fail(function (err) {
                           that.log.error("Error getting system mode status:\n", err);
+                          if (!childBridge){
+                            callback([]);
+                          }
                         });
                     }.bind(this)
                   )
                   .fail(function (err) {
                     that.log.error("Error getting thermostats:\n", err);
+                    if (!childBridge){
+                      callback([]);
+                    }
                   });
               }.bind(this)
             )
             .fail(function (err) {
               that.log.error("Error getting locations:\n", err);
+              if (!childBridge){
+                callback([]);
+              }
             });
         }.bind(this)
       )
       .fail(function (err) {
         // tell me if login did not work!
         that.log.error("Error during login:\n", err);
+        if (!childBridge){
+          callback([]);
+        }
       });
   },
 };


### PR DESCRIPTION
This enables you to have persistent accessories, if you run the plugin within a child bridge. It does this by skipping the `callback([])`, so it doesn't return an empty array to homebridge. This also causes the bridge to hang, which is why you should only enable this inside a child bridge!

Thanks so much to @coolweb for the work on this!