### PR TITLE
Trap many errors that occur when Honeywell server is down

### DIFF
--- a/index.js
+++ b/index.js
@@ -358,7 +358,13 @@ EvohomePlatform.prototype = {
       )
       .fail(function (err) {
         // tell me if login did not work!
-        that.log.error("Error during login:\n", err);
+		// Don't show stack trace, just the error instead. Keep full stack in debug
+		  that.log.error(
+			`Error during login: ${err && err.message ? err.message : String(err)}`
+		  );
+		  that.log.debug(
+			err
+		  );
         if (!this.childBridge) {
           callback([]);
         }
@@ -378,8 +384,11 @@ EvohomePlatform.prototype.renewSession = function () {
       that.log.debug("Renewed Honeywell API authentication token!");
     })
     .fail(function (err) {
+	  // Don't show stack trace, just the error instead. Keep full stack in debug
       that.log.error(
-        "Renewing Honeywell API authentication token failed:\n",
+        `Renewing Honeywell API authentication token failed: ${err && err.message ? err.message : String(err)}`
+      );
+      that.log.debug(
         err
       );
     });
@@ -461,10 +470,9 @@ EvohomePlatform.prototype.periodicUpdate = function () {
                                     oldCurrentTemp != newCurrentTemp &&
                                     service
                                   ) {
-                                    this.log.debug(
-                                      "Updating: " +
+                                    this.log(
                                         device.name +
-                                        " currentTempChange from: " +
+                                        (oldCurrentTemp < newCurrentTemp ? " temp increased from: " : " temp decreased from: ") +
                                         oldCurrentTemp +
                                         " to: " +
                                         newCurrentTemp
@@ -913,7 +921,7 @@ EvohomeThermostatAccessory.prototype = {
               // returns taskId if successful
             });
         } else {
-          that.log(
+          that.log.debug(
             "HEAT or COOL selected, previous state AUTO, HEAT or COOL. Doing nothing."
           );
         }
@@ -966,7 +974,7 @@ EvohomeThermostatAccessory.prototype = {
   setTargetTemperature: function (value, callback) {
     var that = this;
 
-    that.log("Request to set target temperature to " + value);
+    that.log.debug("Request to set target temperature to " + value);
 
     that.targetTemperateToSet = value;
     callback(null, Number(1));

--- a/lib/evohome.js
+++ b/lib/evohome.js
@@ -51,13 +51,29 @@ function Location(json) {
 }
 
 function Timezone(json) {
-  this.timeZoneId = json.timeZoneId;
-  this.displayName = json.displayName;
-  this.offsetMinutes = json.offsetMinutes;
-  this.currentOffsetMinutes = json.currentOffsetMinutes;
-  this.supportsDaylightSaving = json.supportsDaylightSaving;
-}
+// PUZZLED updated condition tests 23/10/2025
+  if (json && typeof json === 'object') {
+    this.timeZoneId = json.timeZoneId || "";
+    this.displayName = json.displayName || "";
+    this.offsetMinutes = json.offsetMinutes || 0;
+    this.currentOffsetMinutes = json.currentOffsetMinutes || 0;
+    this.supportsDaylightSaving = json.supportsDaylightSaving || false;
 
+    if (!json.timeZoneId) {
+    	// PUZZLED additional formatting 4/4/2026, to log the trapped error with faked timestamp
+        console.error('[%s] \x1b[36m%s \x1b[31m%s\x1b[0m', new Date().toLocaleString(), '[Evohome]', 'Timezone is not valid');
+    }
+  } else {
+    // If json is not an object or is missing, assign default values safely
+    this.timeZoneId = "";
+    this.displayName = "";
+    this.offsetMinutes = 0;
+    this.currentOffsetMinutes = 0;
+    this.supportsDaylightSaving = false;
+	// PUZZLED additional formatting 3/4/2026, to log the trapped error with faked timestamp
+	console.error('[%s] \x1b[36m%s \x1b[31m%s\x1b[0m', new Date().toLocaleString(), '[Evohome]', 'Timezone is missing');
+  }
+}
 function Device(json) {
   this.zoneID = json.zoneId;
   this.zoneType = json.zoneType;
@@ -156,22 +172,26 @@ Session.prototype.getLocations = function () {
   return this._request(url).then(function (json) {
     return _.map(json, function (location) {
       var data = {};
-
-      data.locationID = location.locationInfo.locationId;
-      data.name = location.locationInfo.name;
-      data.streetAddress = location.locationInfo.streetAddress;
-      data.city = location.locationInfo.city;
-      data.country = location.locationInfo.country;
-      data.postcode = location.locationInfo.postcode;
-      data.locationType = location.locationInfo.locationType;
-      data.daylightSavingTimeEnabled =
-        location.locationInfo.useDaylightSaveSwitching;
-      data.timeZone = location.locationInfo.timeZone;
-      data.devices = location.gateways[0].temperatureControlSystems[0].zones;
-      data.dhw = location.gateways[0].temperatureControlSystems[0].dhw;
-      data.systemId =
-        location.gateways[0].temperatureControlSystems[0].systemId;
-
+	  // PUZZLED added condition tests 9/4/2025
+	  if (location && location.locationInfo && location.gateways && location.locationInfo.timeZone ) {
+		data.locationID = location.locationInfo.locationId;
+		data.name = location.locationInfo.name;
+		data.streetAddress = location.locationInfo.streetAddress;
+		data.city = location.locationInfo.city;
+		data.country = location.locationInfo.country;
+		data.postcode = location.locationInfo.postcode;
+		data.locationType = location.locationInfo.locationType;
+		data.daylightSavingTimeEnabled =
+			location.locationInfo.useDaylightSaveSwitching;
+		data.timeZone = location.locationInfo.timeZone;
+		data.devices = location.gateways[0].temperatureControlSystems[0].zones;
+		data.dhw = location.gateways[0].temperatureControlSystems[0].dhw;
+		data.systemId =
+			location.gateways[0].temperatureControlSystems[0].systemId;
+	  } else {
+		// PUZZLED additional formatting 3/4/2026, to log the trapped error with faked timestamp
+        console.error('[%s] \x1b[36m%s \x1b[31m%s\x1b[0m', new Date().toLocaleString(), '[Evohome]', 'Location is undefined!');
+	  }
       return new Location(data);
     });
   });
@@ -303,15 +323,23 @@ Session.prototype._renew = function () {
       },
       body: "grant_type=refresh_token&refresh_token=" + self.refreshToken,
     },
+	//PUZZLED added extra checks  3/11/25
     function (err, response) {
       if (err) {
-        deferred.reject(err);
-      } else {
-        try {
-          deferred.resolve(JSON.parse(response.body));
-        } catch (e) {
-          deferred.reject(e);
-        }
+        return deferred.reject(err);
+      }
+      if (!response || response.statusCode !== 200) {
+        return deferred.reject(new Error(`HTTP error ${response ? response.statusCode : 'unknown'}`));
+      }
+      const body = response.body.trim();
+      if (body.startsWith('<')) {
+        // Received HTML instead of JSON, likely an error page
+        return deferred.reject(new Error(`Expected JSON but received HTML: ${body}`));
+      }
+      try {
+        deferred.resolve(JSON.parse(body));
+      } catch (e) {
+        deferred.reject(e);
       }
     }
   );


### PR DESCRIPTION
I've been annoyed by the logs being full of errors and stack traces when provoked by Honeywell outages (or comms issues). I've gradually been fixing these over the last few months and believe I now have most of them managed. All related to issues previously discussed in https://github.com/luc-ass/homebridge-evohome/issues/153. 

There's also an adjustment to the temp logging — A personal preference to highlight if the current temp is increasing or decreasing. Previously discussed in https://github.com/luc-ass/homebridge-evohome/issues/146.