### PR TITLE
Fix Homebridge v2 / HAP-NodeJS v1 compatibility for custom characteristics

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ var evohome = require("./lib/evohome.js");
 var Service, Characteristic;
 var config;
 var FakeGatoHistoryService;
-var inherits = require("util").inherits;
 const moment = require("moment");
 var CustomCharacteristic = {};
 
@@ -26,49 +25,58 @@ module.exports = function (homebridge) {
 
   Service = homebridge.hap.Service;
   Characteristic = homebridge.hap.Characteristic;
+  const Formats = homebridge.hap.Formats;
+  const Units = homebridge.hap.Units;
+  const Perms = homebridge.hap.Perms;
 
-  CustomCharacteristic.ValvePosition = function () {
-    Characteristic.call(
-      this,
-      "Valve position",
-      "E863F12E-079E-48FF-8F27-9C2605A29F52"
-    );
-    this.setProps({
-      format: Characteristic.Formats.UINT8,
-      unit: Characteristic.Units.PERCENTAGE,
-      perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-    });
-    this.value = this.getDefaultValue();
+  CustomCharacteristic.ValvePosition = class extends Characteristic {
+    constructor() {
+      super(
+        "Valve position",
+        "E863F12E-079E-48FF-8F27-9C2605A29F52"
+      );
+      this.setProps({
+        format: Formats.UINT8,
+        unit: Units.PERCENTAGE,
+        perms: [Perms.READ, Perms.NOTIFY],
+      });
+      this.value = this.getDefaultValue();
+    }
   };
-  inherits(CustomCharacteristic.ValvePosition, Characteristic);
+  CustomCharacteristic.ValvePosition.UUID =
+    "E863F12E-079E-48FF-8F27-9C2605A29F52";
 
-  CustomCharacteristic.ProgramCommand = function () {
-    Characteristic.call(
-      this,
-      "Program command",
-      "E863F12C-079E-48FF-8F27-9C2605A29F52"
-    );
-    this.setProps({
-      format: Characteristic.Formats.DATA,
-      perms: [Characteristic.Perms.WRITE, Characteristic.Perms.NOTIFY],
-    });
-    this.value = this.getDefaultValue();
+  CustomCharacteristic.ProgramCommand = class extends Characteristic {
+    constructor() {
+      super(
+        "Program command",
+        "E863F12C-079E-48FF-8F27-9C2605A29F52"
+      );
+      this.setProps({
+        format: Formats.DATA,
+        perms: [Perms.WRITE, Perms.NOTIFY],
+      });
+      this.value = this.getDefaultValue();
+    }
   };
-  inherits(CustomCharacteristic.ProgramCommand, Characteristic);
+  CustomCharacteristic.ProgramCommand.UUID =
+    "E863F12C-079E-48FF-8F27-9C2605A29F52";
 
-  CustomCharacteristic.ProgramData = function () {
-    Characteristic.call(
-      this,
-      "Program data",
-      "E863F12F-079E-48FF-8F27-9C2605A29F52"
-    );
-    this.setProps({
-      format: Characteristic.Formats.DATA,
-      perms: [Characteristic.Perms.READ, Characteristic.Perms.NOTIFY],
-    });
-    this.value = this.getDefaultValue();
+  CustomCharacteristic.ProgramData = class extends Characteristic {
+    constructor() {
+      super(
+        "Program data",
+        "E863F12F-079E-48FF-8F27-9C2605A29F52"
+      );
+      this.setProps({
+        format: Formats.DATA,
+        perms: [Perms.READ, Perms.NOTIFY],
+      });
+      this.value = this.getDefaultValue();
+    }
   };
-  inherits(CustomCharacteristic.ProgramData, Characteristic);
+  CustomCharacteristic.ProgramData.UUID =
+    "E863F12F-079E-48FF-8F27-9C2605A29F52";
 
   homebridge.registerPlatform("homebridge-evohome", "Evohome", EvohomePlatform);
 };

--- a/index.js
+++ b/index.js
@@ -832,7 +832,14 @@ EvohomeThermostatAccessory.prototype = {
 
     // need to refresh data if outdated!!
     var currentTemperature = this.thermostat.temperatureStatus.temperature;
-    callback(null, Number(currentTemperature));
+    // Some zones (e.g. floor-sensor-only rooms) can report undefined.
+    // HAP v2 strictly validates values; an undefined/NaN here would be
+    // rejected. Fall back to the characteristic's minValue (1) instead.
+    var numericTemperature = Number(currentTemperature);
+    if (!Number.isFinite(numericTemperature)) {
+      numericTemperature = 1;
+    }
+    callback(null, numericTemperature);
     that.log.debug(
       "Current temperature of " + this.name + " is " + currentTemperature + "°"
     );
@@ -1043,7 +1050,7 @@ EvohomeThermostatAccessory.prototype = {
     // not implemented
     var data =
       "12f1130014c717040af6010700fc140c170c11fa24366684ffffffff24366684ffffffff24366684ffffffff24366684ffffffff24366684ffffffff24366684ffffffff24366684fffffffff42422222af3381900001a24366684ffffffff";
-    var buffer = new Buffer(
+    var buffer = Buffer.from(
       ("" + data).replace(/[^0-9A-F]/gi, ""),
       "hex"
     ).toString("base64");


### PR DESCRIPTION
## Summary

Fixes the plugin loading on Homebridge v2 / HAP-NodeJS v1, where it currently crashes with `TypeError: Class constructor Characteristic cannot be invoked without 'new'` the moment a thermostat accessory is initialized.

Closes #205.

## Background

HAP-NodeJS v1 (shipped with Homebridge v2) introduced two breaking changes that affect this plugin:

1. **`Characteristic` is now an ES6 class.** It can no longer be invoked as a plain function via `Characteristic.call(this, ...)` followed by `util.inherits(...)`. Attempting this throws `TypeError: Class constructor Characteristic cannot be invoked without 'new'`.
2. **The `Characteristic.Formats` / `Characteristic.Units` / `Characteristic.Perms` static accessors were removed.** They now live on `homebridge.hap.{Formats,Units,Perms}`. Accessing the old paths returns `undefined`, surfacing as e.g. `TypeError: Cannot read properties of undefined (reading 'UINT8')`.

Both changes are documented in the official [Updating To Homebridge v2.0](https://github.com/homebridge/homebridge/wiki/Updating-To-Homebridge-v2.0) wiki page.

## Backward compatibility

The minimum supported Node.js version for this plugin (per `package.json` engines field) already supports ES6 classes, so this change does not raise the Node.js floor. Users on Homebridge v1.x are unaffected.