### PR TITLE
Report faults and battery status to HomeKit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Identisch zu engines.node und zu homebridge@2.4.0 (Entscheidung F2).
+        # Identical to engines.node and to homebridge@2.4.0 (decision F2).
         node: [22, 24, 26]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **Faults and battery status reach HomeKit.** A zone or the hot water reporting
+  `TempZoneActuatorLowBattery` now shows a low battery on that accessory, and
+  any other fault — a lost radio link, a defective sensor — shows as a fault
+  (`StatusFault`). Until now `activeFaults` was read from the API and then only
+  written to the log, where nobody looks. A low battery is deliberately _not_
+  treated as a fault: the valve still measures and still heats. No charge
+  percentage is reported, because the API does not provide one.
+
+### Fixed
+
+- **A fault that was already present when Homebridge started was never logged.**
+  The check compared against the previous status, which does not exist on the
+  first update, so a flat battery at start stayed silent forever. Faults are now
+  logged when they appear and when they clear.
+
 ## 1.0.0-beta.0
 
 A rewrite for **Homebridge 2**. The plugin is now TypeScript, ships as an ES

--- a/README.md
+++ b/README.md
@@ -101,6 +101,27 @@ switched off should not come back on at the next switchpoint.
 | **Heat**      | An override is active                 |
 | **Off**       | The target is at the zone's minimum   |
 
+### Faults and batteries
+
+Evohome reports an `activeFaults` list per zone and for the hot water. Those
+faults now reach HomeKit instead of only the log:
+
+| Fault reported by Evohome                               | In HomeKit                                                   |
+| :------------------------------------------------------ | :----------------------------------------------------------- |
+| Low battery, e.g. `TempZoneActuatorLowBattery`          | Low battery on that accessory — the Home app shows a warning |
+| Anything else, e.g. `TempZoneActuatorCommunicationLost` | A fault on the accessory (`StatusFault`)                     |
+
+A low battery deliberately does **not** count as a fault: an HR92 with a weak
+battery still measures and still heats. Only a real failure — radio link lost,
+sensor defective — makes the values untrustworthy.
+
+The battery status carries no percentage. The API reports whether a battery is
+low, never how full it is, and an invented percentage would be worse than none.
+Every zone gets a battery status, including mains-powered ones such as a zone
+valve; those simply never report a battery fault.
+
+Faults are logged as well, both when they appear and when they clear.
+
 ## 🔄 Upgrading from 0.11.x
 
 **Your accessories are recreated once.** They appear in the default room and

--- a/src/accessories/dhw.ts
+++ b/src/accessories/dhw.ts
@@ -1,4 +1,5 @@
 import { REFRESH_DELAY_MS } from "../settings.js";
+import { faultKey, summarizeFaults } from "../util/faults.js";
 import { nextSwitchpoint } from "../util/schedule.js";
 import { decideOverride } from "../util/setpoint.js";
 
@@ -31,6 +32,7 @@ import type {
 export class DomesticHotWaterAccessory {
   private readonly sensor: Service;
   private readonly toggle: Service;
+  private readonly battery: Service;
   private status: DhwStatus | undefined;
 
   constructor(
@@ -62,6 +64,24 @@ export class DomesticHotWaterAccessory {
       .getCharacteristic(Characteristic.CurrentTemperature)
       .onGet(() => this.temperature());
 
+    // The cylinder sensor (CS92A) runs on batteries and reports
+    // `DHWSensorLowBattery`; the actuator reports a lost connection. Both used
+    // to be parsed and then dropped on the floor.
+    //
+    // Unlike on the thermostat service, StatusFault is a proper optional
+    // characteristic of the temperature sensor, so no addOptionalCharacteristic
+    // is needed here.
+    this.sensor
+      .getCharacteristic(Characteristic.StatusFault)
+      .onGet(() => this.statusFault());
+
+    this.battery =
+      this.accessory.getService(Service.Battery) ??
+      this.accessory.addService(Service.Battery, `${this.name} Battery`);
+    this.battery
+      .getCharacteristic(Characteristic.StatusLowBattery)
+      .onGet(() => this.statusLowBattery());
+
     this.toggle =
       this.accessory.getService(Service.Switch) ??
       this.accessory.addService(Service.Switch, this.name, "dhw-toggle");
@@ -72,8 +92,11 @@ export class DomesticHotWaterAccessory {
   }
 
   update(status: DhwStatus): void {
+    const previous = this.status;
     this.status = status;
     const { Characteristic } = this.api.hap;
+
+    this.logFaultChange(previous?.activeFaults, status.activeFaults);
 
     const temperature = status.temperatureStatus.temperature;
     if (temperature !== undefined) {
@@ -84,6 +107,42 @@ export class DomesticHotWaterAccessory {
     this.toggle
       .getCharacteristic(Characteristic.On)
       .updateValue(status.state === "On");
+    this.sensor
+      .getCharacteristic(Characteristic.StatusFault)
+      .updateValue(this.statusFault());
+    this.battery
+      .getCharacteristic(Characteristic.StatusLowBattery)
+      .updateValue(this.statusLowBattery());
+  }
+
+  /** Logs faults whenever the set of them changes; see the thermostat. */
+  private logFaultChange(
+    previous: readonly string[] | undefined,
+    current: readonly string[],
+  ): void {
+    if (faultKey(previous ?? []) === faultKey(current)) {
+      return;
+    }
+    if (current.length === 0) {
+      this.log.info("Hot water: no active faults any more.");
+      return;
+    }
+    this.log.warn(`Hot water: ${current.join(", ")}.`);
+  }
+
+  /** NO_FAULT before the first poll, for the reasons given in the thermostat. */
+  private statusFault(): number {
+    const { StatusFault } = this.api.hap.Characteristic;
+    return summarizeFaults(this.status?.activeFaults ?? []).fault
+      ? StatusFault.GENERAL_FAULT
+      : StatusFault.NO_FAULT;
+  }
+
+  private statusLowBattery(): number {
+    const { StatusLowBattery } = this.api.hap.Characteristic;
+    return summarizeFaults(this.status?.activeFaults ?? []).lowBattery
+      ? StatusLowBattery.BATTERY_LEVEL_LOW
+      : StatusLowBattery.BATTERY_LEVEL_NORMAL;
   }
 
   get lastStatus(): DhwStatus | undefined {

--- a/src/accessories/dhw.ts
+++ b/src/accessories/dhw.ts
@@ -1,13 +1,14 @@
 import { REFRESH_DELAY_MS } from "../settings.js";
 import { faultKey, summarizeFaults } from "../util/faults.js";
 import { nextSwitchpoint } from "../util/schedule.js";
-import { decideOverride } from "../util/setpoint.js";
+import { decideOverride, needsSwitchpoint } from "../util/setpoint.js";
 
 import type { ScheduleCache } from "../api/scheduleCache.js";
 import type { EvohomeClient } from "../api/client.js";
 import type { DhwStatus } from "../api/types.js";
 import type { EvohomeConfig } from "../config.js";
 import type { PollingCoordinator } from "../polling.js";
+import type { CurrentOverride } from "../util/setpoint.js";
 import type {
   API,
   CharacteristicValue,
@@ -177,10 +178,14 @@ export class DomesticHotWaterAccessory {
     const now = new Date();
 
     // Hot water follows the same rule as the heating zones (issue #149).
+    const current: CurrentOverride = {
+      setpointMode: this.required().mode,
+      until: this.required().until,
+    };
     const decision = decideOverride(
       this.config.setpointMode,
-      { setpointMode: this.required().mode, until: this.required().until },
-      await this.nextSwitchpoint(now),
+      current,
+      await this.nextSwitchpoint(now, current),
       now,
     );
 
@@ -194,8 +199,12 @@ export class DomesticHotWaterAccessory {
     this.poller.scheduleRefresh(REFRESH_DELAY_MS);
   }
 
-  private async nextSwitchpoint(now: Date): Promise<Date | undefined> {
-    if (this.config.setpointMode === "permanent") {
+  /** Next switchpoint, fetched only when the decision can still use it. */
+  private async nextSwitchpoint(
+    now: Date,
+    current: CurrentOverride,
+  ): Promise<Date | undefined> {
+    if (!needsSwitchpoint(this.config.setpointMode, current, now)) {
       return undefined;
     }
     const schedule = await this.schedules.dhw(this.dhwId);

--- a/src/accessories/thermostat.ts
+++ b/src/accessories/thermostat.ts
@@ -1,4 +1,5 @@
 import { REFRESH_DELAY_MS } from "../settings.js";
+import { faultKey, summarizeFaults } from "../util/faults.js";
 import { nextSwitchpoint } from "../util/schedule.js";
 import { decideOverride } from "../util/setpoint.js";
 
@@ -51,6 +52,7 @@ export const clampSetpoint = (
 
 export class ThermostatAccessory {
   private readonly service: Service;
+  private readonly battery: Service;
   private readonly log: Logging;
   private status: ZoneStatus | undefined;
 
@@ -121,6 +123,33 @@ export class ThermostatAccessory {
       .getCharacteristic(Characteristic.TemperatureDisplayUnits)
       .onGet(() => Characteristic.TemperatureDisplayUnits.CELSIUS);
 
+    // `activeFaults` used to end up in the log only, where nobody looks. A lost
+    // radio link to an actuator now reaches the Home app as well.
+    //
+    // StatusFault is not among the thermostat service's optional
+    // characteristics, so it has to be registered explicitly — as with the Eve
+    // characteristic below, getCharacteristic() would add it by itself but write
+    // an "Adding anyway" warning into the log while doing so.
+    this.service.addOptionalCharacteristic(Characteristic.StatusFault);
+    this.service
+      .getCharacteristic(Characteristic.StatusFault)
+      .onGet(() => this.statusFault());
+
+    // A battery service without `BatteryLevel`: the API reports whether a
+    // battery is low, never how full it is, and a made-up percentage would be
+    // worse than none — the same reasoning as for the hot water history.
+    //
+    // Every zone gets one, including the mains-powered ones (`ZoneValves`,
+    // `ElectricHeat`). Those simply never report a battery fault, which costs
+    // nothing; leaving out the service would need a zone-type allowlist that
+    // goes stale the moment Resideo adds a model.
+    this.battery =
+      this.accessory.getService(Service.Battery) ??
+      this.accessory.addService(Service.Battery, `${this.zone.name} Battery`);
+    this.battery
+      .getCharacteristic(Characteristic.StatusLowBattery)
+      .onGet(() => this.statusLowBattery());
+
     // Eve shows the valve position in its history. The value is derived; the API
     // reports no real valve position.
     //
@@ -139,9 +168,7 @@ export class ThermostatAccessory {
     this.status = status;
     const { Characteristic } = this.api.hap;
 
-    if (status.activeFaults.length > 0 && previous?.activeFaults.length === 0) {
-      this.log.warn(`${this.zone.name}: ${status.activeFaults.join(", ")}`);
-    }
+    this.logFaultChange(previous?.activeFaults, status.activeFaults);
 
     const temperature = status.temperatureStatus.temperature;
     if (temperature !== undefined) {
@@ -163,8 +190,58 @@ export class ThermostatAccessory {
     this.service
       .getCharacteristic(Characteristic.TargetHeatingCoolingState)
       .updateValue(this.targetState());
+    this.service
+      .getCharacteristic(Characteristic.StatusFault)
+      .updateValue(this.statusFault());
+    this.battery
+      .getCharacteristic(Characteristic.StatusLowBattery)
+      .updateValue(this.statusLowBattery());
 
     this.recordHistory(status);
+  }
+
+  /**
+   * Logs faults whenever the set of them changes.
+   *
+   * The earlier condition was `previous?.activeFaults.length === 0`, which is
+   * never true on the first update because `previous` is undefined then: a zone
+   * whose battery was already flat when Homebridge started stayed silent
+   * forever. Recovery was never reported either.
+   */
+  private logFaultChange(
+    previous: readonly string[] | undefined,
+    current: readonly string[],
+  ): void {
+    if (faultKey(previous ?? []) === faultKey(current)) {
+      return;
+    }
+    if (current.length === 0) {
+      this.log.info(`${this.zone.name}: no active faults any more.`);
+      return;
+    }
+    this.log.warn(`${this.zone.name}: ${current.join(", ")}.`);
+  }
+
+  /**
+   * Fault state for HomeKit.
+   *
+   * Unlike the other getters this one does not throw before the first poll.
+   * `StatusFault` has no "unknown" value, and answering NO_FAULT is the honest
+   * option — reporting a fault the system never mentioned would be a false
+   * alarm, and an error would make the whole accessory look unreachable.
+   */
+  private statusFault(): number {
+    const { StatusFault } = this.api.hap.Characteristic;
+    return summarizeFaults(this.status?.activeFaults ?? []).fault
+      ? StatusFault.GENERAL_FAULT
+      : StatusFault.NO_FAULT;
+  }
+
+  private statusLowBattery(): number {
+    const { StatusLowBattery } = this.api.hap.Characteristic;
+    return summarizeFaults(this.status?.activeFaults ?? []).lowBattery
+      ? StatusLowBattery.BATTERY_LEVEL_LOW
+      : StatusLowBattery.BATTERY_LEVEL_NORMAL;
   }
 
   /**

--- a/src/accessories/thermostat.ts
+++ b/src/accessories/thermostat.ts
@@ -1,7 +1,7 @@
 import { REFRESH_DELAY_MS } from "../settings.js";
 import { faultKey, summarizeFaults } from "../util/faults.js";
 import { nextSwitchpoint } from "../util/schedule.js";
-import { decideOverride } from "../util/setpoint.js";
+import { decideOverride, needsSwitchpoint } from "../util/setpoint.js";
 
 import type { ScheduleCache } from "../api/scheduleCache.js";
 import type { HistoryService } from "../history.js";
@@ -10,6 +10,7 @@ import type { SetpointCapabilities, Zone, ZoneStatus } from "../api/types.js";
 import type { EvohomeConfig } from "../config.js";
 import type { EveCharacteristics } from "../characteristics/eve.js";
 import type { PollingCoordinator } from "../polling.js";
+import type { CurrentOverride } from "../util/setpoint.js";
 import type {
   API,
   CharacteristicValue,
@@ -382,10 +383,11 @@ export class ThermostatAccessory {
     // Issue #149: if a temporary override is already running, the default
     // `keepExistingUntil` adopts its end time instead of replacing it with the
     // next switchpoint.
+    const current = this.required().setpointStatus;
     const decision = decideOverride(
       this.config.setpointMode,
-      this.required().setpointStatus,
-      await this.nextSwitchpoint(now),
+      current,
+      await this.nextSwitchpoint(now, current),
       now,
     );
 
@@ -404,11 +406,14 @@ export class ThermostatAccessory {
   /**
    * Next switchpoint in this zone's schedule.
    *
-   * With `permanent` the schedule is not fetched at all; the call would be pure
-   * load on Honeywell's servers.
+   * Fetched only when the decision can still use it; otherwise the call would
+   * be pure load on Honeywell's servers. See {@link needsSwitchpoint}.
    */
-  private async nextSwitchpoint(now: Date): Promise<Date | undefined> {
-    if (this.config.setpointMode === "permanent") {
+  private async nextSwitchpoint(
+    now: Date,
+    current: CurrentOverride,
+  ): Promise<Date | undefined> {
+    if (!needsSwitchpoint(this.config.setpointMode, current, now)) {
       return undefined;
     }
     const schedule = await this.schedules.zone(this.zone.zoneId);

--- a/src/api/parse.ts
+++ b/src/api/parse.ts
@@ -287,6 +287,10 @@ const parseDhwStatus = (raw: unknown, path: string): DhwStatus => {
     state: asEnum(state["state"], `${path}.stateStatus.state`, DHW_STATES),
     mode: asEnum(state["mode"], `${path}.stateStatus.mode`, SETPOINT_MODES),
     until: asDate(state["until"], `${path}.stateStatus.until`),
+    activeFaults: parseActiveFaults(
+      json["activeFaults"],
+      `${path}.activeFaults`,
+    ),
   };
 };
 

--- a/src/api/tokenCache.ts
+++ b/src/api/tokenCache.ts
@@ -47,16 +47,29 @@ export class FileTokenCache implements TokenCache {
   }
 
   async write(tokens: Tokens | undefined): Promise<void> {
+    if (tokens === undefined) {
+      await this.remove();
+      return;
+    }
     try {
-      if (tokens === undefined) {
-        await unlink(this.file);
-        return;
-      }
       // 0o600: only the Homebridge user may read the token.
       await writeFile(this.file, JSON.stringify(tokens), { mode: 0o600 });
     } catch (error) {
+      // Every failure is reported here, ENOENT included: for a write that means
+      // the storage directory does not exist, and silently never persisting a
+      // session is precisely the kind of failure that is impossible to
+      // diagnose from a bug report.
+      this.log.debug(`Could not store the session: ${String(error)}`);
+    }
+  }
+
+  private async remove(): Promise<void> {
+    try {
+      await unlink(this.file);
+    } catch (error) {
+      // Nothing stored yet is the normal case, not a problem.
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        this.log.debug(`Could not store the session: ${String(error)}`);
+        this.log.debug(`Could not delete the stored session: ${String(error)}`);
       }
     }
   }

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -134,6 +134,8 @@ export interface DhwStatus {
   readonly state: DhwState;
   readonly mode: SetpointMode;
   readonly until: Date | undefined;
+  /** Active faults, e.g. `DHWSensorLowBattery`. */
+  readonly activeFaults: readonly string[];
 }
 
 export interface SystemModeStatus {

--- a/src/util/faults.ts
+++ b/src/util/faults.ts
@@ -1,0 +1,48 @@
+/**
+ * Interprets the `activeFaults` that the API reports per zone and for the hot
+ * water.
+ *
+ * Until now those strings only ever reached the log, so a flat HR92 battery was
+ * invisible in the Home app — even though the API says so explicitly: a zone
+ * reports `TempZoneActuatorLowBattery` long before it stops sending a
+ * temperature at all.
+ *
+ * Fault types are matched by substring rather than against a list of known
+ * names. Resideo adds new ones without announcing it
+ * (`TempZoneSensorLowBattery`, `DHWSensorFailure`,
+ * `BoilerCommunicationLost`, …), and a closed list would silently ignore
+ * everything that is not on it.
+ */
+
+export interface FaultSummary {
+  /** A fault other than a low battery, e.g. a lost radio link. */
+  readonly fault: boolean;
+  /** At least one component of this zone reports a low battery. */
+  readonly lowBattery: boolean;
+}
+
+/** Does this fault type describe a low battery? */
+export const isLowBattery = (faultType: string): boolean =>
+  faultType.toLowerCase().includes("lowbattery");
+
+/**
+ * Splits the faults into the two things HomeKit can express.
+ *
+ * A low battery deliberately does **not** also raise `StatusFault`: an HR92
+ * with a weak battery still reports and still heats. Only a genuine failure —
+ * communication lost, sensor defective — makes the values untrustworthy, and
+ * that is what `StatusFault` should mean.
+ */
+export const summarizeFaults = (faults: readonly string[]): FaultSummary => ({
+  fault: faults.some((faultType) => !isLowBattery(faultType)),
+  lowBattery: faults.some(isLowBattery),
+});
+
+/**
+ * Comparable form of a fault list, for spotting a change.
+ *
+ * Sorted, because the API gives no guarantee about the order and a reordered
+ * but otherwise identical list is not a change worth logging.
+ */
+export const faultKey = (faults: readonly string[]): string =>
+  [...faults].sort().join(", ");

--- a/src/util/setpoint.ts
+++ b/src/util/setpoint.ts
@@ -82,6 +82,25 @@ export const decideOverride = (
   };
 };
 
+/**
+ * Does the decision still need the next switchpoint?
+ *
+ * The accessories ask before fetching the schedule. With `permanent`, or with a
+ * running override under `keepExistingUntil`, {@link decideOverride} discards
+ * the switchpoint anyway — and fetching it costs a request on the write path,
+ * which is exactly what the schedule cache exists to avoid.
+ *
+ * The rule lives here rather than in the accessories so that it cannot drift
+ * apart from the decision it mirrors.
+ */
+export const needsSwitchpoint = (
+  strategy: SetpointStrategy,
+  current: CurrentOverride,
+  now: Date,
+): boolean =>
+  strategy !== "permanent" &&
+  !(strategy === "keepExistingUntil" && isRunning(current, now));
+
 /** Is a temporary override running whose end time is still ahead? */
 const isRunning = (current: CurrentOverride, now: Date): boolean =>
   current.setpointMode === "TemporaryOverride" &&

--- a/test/accessories/dhw.test.ts
+++ b/test/accessories/dhw.test.ts
@@ -1,0 +1,352 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DomesticHotWaterAccessory } from "../../src/accessories/dhw.js";
+import { createTestApi, createTestLog, hap, type TestApi } from "../hapStub.js";
+
+import type { EvohomeClient } from "../../src/api/client.js";
+import type { ScheduleCache } from "../../src/api/scheduleCache.js";
+import type { DhwStatus } from "../../src/api/types.js";
+import type { EvohomeConfig } from "../../src/config.js";
+import type { PollingCoordinator } from "../../src/polling.js";
+import type { PlatformAccessory, Service } from "homebridge";
+
+const DHW_ID = "9001";
+
+const config = (overrides: Partial<EvohomeConfig> = {}): EvohomeConfig => ({
+  name: "Evohome",
+  username: "user@example.com",
+  password: "secret",
+  locationId: undefined,
+  locationIndex: 0,
+  pollIntervalSeconds: 300,
+  temperatureAboveAsOff: false,
+  showSwitches: {
+    Away: true,
+    DayOff: true,
+    HeatingOff: true,
+    AutoWithEco: true,
+    Custom: true,
+  },
+  history: false,
+  setpointMode: "keepExistingUntil",
+  logTemperatureChanges: false,
+  ...overrides,
+});
+
+const status = (overrides: Partial<DhwStatus> = {}): DhwStatus => ({
+  dhwId: DHW_ID,
+  temperatureStatus: { temperature: 48.5, isAvailable: true },
+  state: "On",
+  mode: "FollowSchedule",
+  until: undefined,
+  activeFaults: [],
+  ...overrides,
+});
+
+/** Mondays 06:00 On, 09:00 Off — the schedule from the fixtures. */
+const dailySchedules = [
+  {
+    dayOfWeek: "Monday",
+    switchpoints: [
+      { timeOfDay: "06:00:00", heatSetpoint: undefined, dhwState: "On" },
+      { timeOfDay: "09:00:00", heatSetpoint: undefined, dhwState: "Off" },
+    ],
+  },
+] as const;
+
+describe("DomesticHotWaterAccessory", () => {
+  let test: TestApi;
+  let log: ReturnType<typeof createTestLog>;
+  let accessory: PlatformAccessory;
+  let setDhwState: ReturnType<typeof vi.fn>;
+  let scheduleRefresh: ReturnType<typeof vi.fn>;
+  let dhwSchedule: ReturnType<typeof vi.fn>;
+
+  const build = (cfg: EvohomeConfig = config()): DomesticHotWaterAccessory =>
+    new DomesticHotWaterAccessory(
+      test.api,
+      accessory,
+      DHW_ID,
+      "Evohome Hot Water",
+      { setDhwState } as unknown as EvohomeClient,
+      { scheduleRefresh } as unknown as PollingCoordinator,
+      { dhw: dhwSchedule } as unknown as ScheduleCache,
+      cfg,
+      0,
+      log,
+    );
+
+  const sensor = (): Service =>
+    accessory.getService(hap.Service.TemperatureSensor)!;
+  const toggle = (): Service => accessory.getService(hap.Service.Switch)!;
+  const battery = (): Service => accessory.getService(hap.Service.Battery)!;
+
+  beforeEach(() => {
+    test = createTestApi();
+    log = createTestLog();
+    accessory = new test.api.platformAccessory(
+      "Evohome Hot Water",
+      hap.uuid.generate("evohome:dhw:9001"),
+    );
+    setDhwState = vi.fn().mockResolvedValue({ id: "task-1" });
+    scheduleRefresh = vi.fn();
+    dhwSchedule = vi.fn().mockResolvedValue(dailySchedules);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("services", () => {
+    it("identifies itself with the hot water id", () => {
+      build();
+
+      const info = accessory.getService(hap.Service.AccessoryInformation)!;
+      expect(
+        info.getCharacteristic(hap.Characteristic.SerialNumber).value,
+      ).toBe(DHW_ID);
+    });
+
+    it("reuses the services of a cached accessory", () => {
+      build();
+      const first = sensor();
+
+      build();
+
+      // A second accessory would leave HomeKit with a duplicate that never
+      // updates.
+      expect(sensor()).toBe(first);
+      expect(
+        accessory.services.filter((s) => s.UUID === first.UUID),
+      ).toHaveLength(1);
+    });
+  });
+
+  describe("update", () => {
+    it("passes temperature and state on to HomeKit", () => {
+      const dhw = build();
+
+      dhw.update(
+        status({ temperatureStatus: { temperature: 51, isAvailable: true } }),
+      );
+
+      expect(
+        sensor().getCharacteristic(hap.Characteristic.CurrentTemperature).value,
+      ).toBe(51);
+      expect(toggle().getCharacteristic(hap.Characteristic.On).value).toBe(
+        true,
+      );
+      expect(dhw.lastStatus?.state).toBe("On");
+    });
+
+    it("keeps the last temperature when the sensor reports none", () => {
+      const dhw = build();
+      dhw.update(status());
+
+      dhw.update(
+        status({
+          temperatureStatus: { temperature: undefined, isAvailable: false },
+        }),
+      );
+
+      // Better a slightly stale reading than 0 °C in the Home app.
+      expect(
+        sensor().getCharacteristic(hap.Characteristic.CurrentTemperature).value,
+      ).toBe(48.5);
+    });
+
+    it("reports a low battery without raising a fault", () => {
+      const dhw = build();
+
+      dhw.update(status({ activeFaults: ["DHWSensorLowBattery"] }));
+
+      // A CS92A with a weak battery still measures; only StatusLowBattery
+      // should react.
+      expect(
+        battery().getCharacteristic(hap.Characteristic.StatusLowBattery).value,
+      ).toBe(hap.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+      expect(
+        sensor().getCharacteristic(hap.Characteristic.StatusFault).value,
+      ).toBe(hap.Characteristic.StatusFault.NO_FAULT);
+    });
+
+    it("raises a fault for anything that is not a battery", () => {
+      const dhw = build();
+
+      dhw.update(status({ activeFaults: ["DHWSensorFailure"] }));
+
+      expect(
+        sensor().getCharacteristic(hap.Characteristic.StatusFault).value,
+      ).toBe(hap.Characteristic.StatusFault.GENERAL_FAULT);
+      expect(
+        battery().getCharacteristic(hap.Characteristic.StatusLowBattery).value,
+      ).toBe(hap.Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+    });
+
+    it("clears a fault again once it is gone", () => {
+      const dhw = build();
+      dhw.update(status({ activeFaults: ["DHWSensorFailure"] }));
+
+      dhw.update(status({ activeFaults: [] }));
+
+      expect(
+        sensor().getCharacteristic(hap.Characteristic.StatusFault).value,
+      ).toBe(hap.Characteristic.StatusFault.NO_FAULT);
+      expect(log.infos.join()).toContain("no active faults");
+    });
+
+    it("logs a fault once, not on every poll", () => {
+      const dhw = build();
+
+      dhw.update(status({ activeFaults: ["DHWSensorFailure"] }));
+      dhw.update(status({ activeFaults: ["DHWSensorFailure"] }));
+      // The API gives no guarantee about the order, and a reordering is not a
+      // change.
+      dhw.update(status({ activeFaults: ["DHWSensorFailure"] }));
+
+      expect(log.warnings).toHaveLength(1);
+    });
+  });
+
+  describe("reads before the first poll", () => {
+    it("answers with a communication failure rather than a made-up value", async () => {
+      build();
+
+      await expect(
+        sensor()
+          .getCharacteristic(hap.Characteristic.CurrentTemperature)
+          .handleGetRequest(),
+      ).rejects.toBeDefined();
+      await expect(
+        toggle().getCharacteristic(hap.Characteristic.On).handleGetRequest(),
+      ).rejects.toBeDefined();
+    });
+
+    it("reports no fault rather than an unknown one", async () => {
+      build();
+
+      await expect(
+        sensor()
+          .getCharacteristic(hap.Characteristic.StatusFault)
+          .handleGetRequest(),
+      ).resolves.toBe(hap.Characteristic.StatusFault.NO_FAULT);
+      await expect(
+        battery()
+          .getCharacteristic(hap.Characteristic.StatusLowBattery)
+          .handleGetRequest(),
+      ).resolves.toBe(hap.Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+    });
+
+    it("fails the temperature read when the sensor reports none", async () => {
+      const dhw = build();
+      dhw.update(
+        status({
+          temperatureStatus: { temperature: undefined, isAvailable: false },
+        }),
+      );
+
+      await expect(
+        sensor()
+          .getCharacteristic(hap.Characteristic.CurrentTemperature)
+          .handleGetRequest(),
+      ).rejects.toBeDefined();
+    });
+  });
+
+  describe("switching (issue #149)", () => {
+    const setOn = async (value: boolean): Promise<void> => {
+      await toggle()
+        .getCharacteristic(hap.Characteristic.On)
+        .handleSetRequest(value);
+    };
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-09-07T07:30:00Z")); // a Monday
+    });
+
+    it("keeps the end time of a running override", async () => {
+      const until = new Date("2026-09-07T20:30:00Z");
+      const dhw = build();
+      dhw.update(status({ mode: "TemporaryOverride", until, state: "On" }));
+
+      await setOn(false);
+
+      // The bug from 0.11.2: it overwrote 20:30 with the next switchpoint.
+      expect(setDhwState).toHaveBeenCalledWith(
+        DHW_ID,
+        "TemporaryOverride",
+        "Off",
+        until,
+      );
+      // The schedule is not needed for this decision, and fetching it would put
+      // a request on the write path — what ScheduleCache exists to avoid.
+      expect(dhwSchedule).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the next switchpoint without a running override", async () => {
+      const dhw = build();
+      dhw.update(status({ mode: "FollowSchedule" }));
+
+      await setOn(false);
+
+      expect(setDhwState).toHaveBeenCalledWith(
+        DHW_ID,
+        "TemporaryOverride",
+        "Off",
+        new Date("2026-09-07T09:00:00Z"),
+      );
+    });
+
+    it("writes a permanent override when configured to", async () => {
+      const dhw = build(config({ setpointMode: "permanent" }));
+      dhw.update(status());
+
+      await setOn(true);
+
+      expect(setDhwState).toHaveBeenCalledWith(
+        DHW_ID,
+        "PermanentOverride",
+        "On",
+        undefined,
+      );
+      // No schedule is needed for a permanent override.
+      expect(dhwSchedule).not.toHaveBeenCalled();
+    });
+
+    it("goes permanent when the schedule holds no later switchpoint", async () => {
+      vi.setSystemTime(new Date("2026-09-07T23:30:00Z"));
+      dhwSchedule.mockResolvedValue([]);
+      const dhw = build();
+      dhw.update(status({ mode: "FollowSchedule" }));
+
+      await setOn(true);
+
+      // 0.11.2 wrote "00:00:00" here, so the setpoint expired immediately.
+      expect(setDhwState).toHaveBeenCalledWith(
+        DHW_ID,
+        "PermanentOverride",
+        "On",
+        undefined,
+      );
+    });
+
+    it("asks for a fresh poll so HomeKit does not keep the old state", async () => {
+      const dhw = build();
+      dhw.update(status());
+
+      await setOn(false);
+
+      expect(scheduleRefresh).toHaveBeenCalled();
+    });
+
+    it("answers immediately instead of timing out (issue #180)", async () => {
+      const dhw = build();
+      dhw.update(status());
+
+      // 0.11.2 called its callback only on failure, so a successful switch ran
+      // into HomeKit's ~15s timeout and showed "Error Action Set Failed".
+      await expect(setOn(true)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/test/api/parse.test.ts
+++ b/test/api/parse.test.ts
@@ -140,6 +140,7 @@ describe("parseLocationStatus", () => {
       state: "On",
       mode: "TemporaryOverride",
       until: new Date("2026-09-03T20:00:00Z"),
+      activeFaults: [],
     });
   });
 });

--- a/test/api/tokenCache.test.ts
+++ b/test/api/tokenCache.test.ts
@@ -1,0 +1,173 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { FileTokenCache } from "../../src/api/tokenCache.js";
+import { createTestLog, type TestLog } from "../hapStub.js";
+
+import type { Tokens } from "../../src/api/types.js";
+
+const tokens: Tokens = {
+  accessToken: "access-1",
+  refreshToken: "refresh-1",
+  expiresAt: 1_800_000_000_000,
+};
+
+/** The single file the cache uses for this storage path and username. */
+const onlyFile = async (storagePath: string): Promise<string> => {
+  const entries = await readdir(storagePath);
+  expect(entries).toHaveLength(1);
+  return join(storagePath, entries[0]!);
+};
+
+describe("FileTokenCache", () => {
+  let storagePath: string;
+  let log: TestLog;
+  let cache: FileTokenCache;
+
+  beforeEach(() => {
+    storagePath = mkdtempSync(join(tmpdir(), "evohome-tokens-"));
+    log = createTestLog();
+    cache = new FileTokenCache(storagePath, "User@Example.com", log);
+  });
+
+  describe("file name", () => {
+    it("keeps the username out of the file system", async () => {
+      await cache.write(tokens);
+
+      const file = await onlyFile(storagePath);
+      expect(file).not.toContain("User");
+      expect(file).not.toContain("example.com");
+      expect(file).toMatch(/evohome-session-[0-9a-f]{12}\.json$/);
+    });
+
+    it("ignores the case of the username, so one account uses one file", async () => {
+      await cache.write(tokens);
+      await new FileTokenCache(storagePath, "user@example.com", log).write(
+        tokens,
+      );
+
+      // Both wrote to the same file, otherwise there would be two.
+      await onlyFile(storagePath);
+    });
+
+    it("gives a second account a file of its own", async () => {
+      await cache.write(tokens);
+      await new FileTokenCache(storagePath, "other@example.com", log).write(
+        tokens,
+      );
+
+      expect(await readdir(storagePath)).toHaveLength(2);
+    });
+  });
+
+  describe("read", () => {
+    it("returns what was written", async () => {
+      await cache.write(tokens);
+
+      expect(await cache.read()).toEqual(tokens);
+    });
+
+    it("returns undefined without a stored session and stays quiet about it", async () => {
+      expect(await cache.read()).toBeUndefined();
+      // A missing file is the normal first start, not something to report.
+      expect(log.debug).not.toHaveBeenCalled();
+    });
+
+    it("survives a truncated file", async () => {
+      // The realistic case: the power goes on a Pi mid-write.
+      await cache.write(tokens);
+      writeFileSync(await onlyFile(storagePath), '{"accessToken":"acc');
+
+      expect(await cache.read()).toBeUndefined();
+      expect(log.debug).toHaveBeenCalled();
+    });
+
+    it.each([
+      ["a missing refreshToken", { accessToken: "a", expiresAt: 1 }],
+      ["a missing accessToken", { refreshToken: "r", expiresAt: 1 }],
+      ["a missing expiresAt", { accessToken: "a", refreshToken: "r" }],
+      [
+        "an expiresAt that is not a number",
+        { accessToken: "a", refreshToken: "r", expiresAt: "soon" },
+      ],
+      ["JSON that is not an object", "just a string"],
+      ["null", null],
+    ])("rejects a session with %s", async (_name, content) => {
+      await cache.write(tokens);
+      writeFileSync(await onlyFile(storagePath), JSON.stringify(content));
+
+      // Half a token pair is worse than none: it would be sent to Honeywell,
+      // rejected, and only then trigger a fresh login.
+      expect(await cache.read()).toBeUndefined();
+    });
+  });
+
+  describe("write", () => {
+    it("stores the session readable only by the Homebridge user", async () => {
+      await cache.write(tokens);
+
+      const mode = statSync(await onlyFile(storagePath)).mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+
+    it("deletes the session when given undefined", async () => {
+      await cache.write(tokens);
+      await cache.write(undefined);
+
+      expect(await readdir(storagePath)).toHaveLength(0);
+      expect(await cache.read()).toBeUndefined();
+    });
+
+    it("stays quiet when there is nothing to delete", async () => {
+      await cache.write(undefined);
+
+      expect(log.debug).not.toHaveBeenCalled();
+    });
+
+    it("does not throw when the storage path is gone", async () => {
+      const broken = new FileTokenCache(
+        join(storagePath, "does", "not", "exist"),
+        "user@example.com",
+        log,
+      );
+
+      // A failed write costs one extra login, nothing more; it must never take
+      // the plugin down. But it has to be visible: a missing storage directory
+      // raises ENOENT, which used to be swallowed along with the "nothing to
+      // delete" case, so the session was silently never persisted.
+      await expect(broken.write(tokens)).resolves.toBeUndefined();
+      expect(log.debug).toHaveBeenCalled();
+    });
+
+    it("reports a failed delete that is not just a missing file", async () => {
+      await cache.write(tokens);
+      const file = await onlyFile(storagePath);
+      rmSync(file);
+      mkdirSync(file);
+
+      await expect(cache.write(undefined)).resolves.toBeUndefined();
+      expect(log.debug).toHaveBeenCalled();
+    });
+
+    it("reports a write that failed for any other reason", async () => {
+      // A directory where the file belongs: EISDIR instead of ENOENT.
+      await cache.write(tokens);
+      const file = await onlyFile(storagePath);
+      rmSync(file);
+      mkdirSync(file);
+
+      await expect(cache.write(tokens)).resolves.toBeUndefined();
+      expect(log.debug).toHaveBeenCalled();
+    });
+  });
+});

--- a/test/platform.test.ts
+++ b/test/platform.test.ts
@@ -51,7 +51,7 @@ const serviceOf = (
 ): Service => {
   const service = accessory.getService(type as never);
   if (service === undefined) {
-    throw new Error("Service fehlt");
+    throw new Error("Service is missing");
   }
   return service;
 };
@@ -183,7 +183,7 @@ describe("EvohomePlatform", () => {
       await startPlatform();
       const accessory = test.registered.find((a) => nameOf(a) === name);
       if (accessory === undefined) {
-        throw new Error(`Accessory ${name} fehlt`);
+        throw new Error(`Accessory ${name} is missing`);
       }
       return serviceOf(accessory, hap.Service.Thermostat);
     };
@@ -358,6 +358,142 @@ describe("EvohomePlatform", () => {
           .getCharacteristic(hap.Characteristic.CurrentTemperature)
           .handleGetRequest(),
       ).resolves.toBe(54.5);
+    });
+  });
+
+  describe("faults and battery", () => {
+    /** The fixture with a replaced fault list on the "Wohnzimmer" zone. */
+    const statusWithZoneFault = (faultType: string): Response => {
+      const status = fixture("locationStatus.json") as {
+        gateways: {
+          temperatureControlSystems: {
+            zones: { activeFaults: unknown[] }[];
+          }[];
+        }[];
+      };
+      status.gateways[0]!.temperatureControlSystems[0]!.zones[0]!.activeFaults =
+        [{ faultType, since: "2026-09-01T07:12:00Z" }];
+      return jsonResponse(status);
+    };
+
+    const accessoryNamed = (name: string): PlatformAccessory => {
+      const accessory = test.registered.find((a) => nameOf(a) === name);
+      if (accessory === undefined) {
+        throw new Error(`Accessory ${name} is missing`);
+      }
+      return accessory;
+    };
+
+    it("reports a low battery on the zone that has one", async () => {
+      // The "Flur" zone reports TempZoneActuatorLowBattery in the fixture.
+      await startPlatform();
+      const flur = serviceOf(
+        accessoryNamed("Flur Thermostat"),
+        hap.Service.Battery,
+      );
+      const wohnzimmer = serviceOf(
+        accessoryNamed("Wohnzimmer Thermostat"),
+        hap.Service.Battery,
+      );
+
+      await expect(
+        flur
+          .getCharacteristic(hap.Characteristic.StatusLowBattery)
+          .handleGetRequest(),
+      ).resolves.toBe(hap.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+      await expect(
+        wohnzimmer
+          .getCharacteristic(hap.Characteristic.StatusLowBattery)
+          .handleGetRequest(),
+      ).resolves.toBe(hap.Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+    });
+
+    it("does not declare a zone faulty just because its battery is low", async () => {
+      await startPlatform();
+      const service = serviceOf(
+        accessoryNamed("Flur Thermostat"),
+        hap.Service.Thermostat,
+      );
+
+      await expect(
+        service
+          .getCharacteristic(hap.Characteristic.StatusFault)
+          .handleGetRequest(),
+      ).resolves.toBe(hap.Characteristic.StatusFault.NO_FAULT);
+    });
+
+    it("reports a lost radio link as a fault", async () => {
+      fetchMock = routedFetch({
+        "/status": () =>
+          statusWithZoneFault("TempZoneActuatorCommunicationLost"),
+      });
+      vi.stubGlobal("fetch", fetchMock);
+      await startPlatform();
+      const accessory = accessoryNamed("Wohnzimmer Thermostat");
+
+      await expect(
+        serviceOf(accessory, hap.Service.Thermostat)
+          .getCharacteristic(hap.Characteristic.StatusFault)
+          .handleGetRequest(),
+      ).resolves.toBe(hap.Characteristic.StatusFault.GENERAL_FAULT);
+      // …and the battery stays normal.
+      await expect(
+        serviceOf(accessory, hap.Service.Battery)
+          .getCharacteristic(hap.Characteristic.StatusLowBattery)
+          .handleGetRequest(),
+      ).resolves.toBe(hap.Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+    });
+
+    it("registers StatusFault as optional to avoid a HAP warning", async () => {
+      // HAP does not list StatusFault among the thermostat service's optional
+      // characteristics. Without addOptionalCharacteristic() it is still added,
+      // but with a "Adding anyway" characteristic warning per zone and start.
+      await startPlatform();
+      const service = serviceOf(
+        accessoryNamed("Wohnzimmer Thermostat"),
+        hap.Service.Thermostat,
+      );
+
+      expect(
+        service.optionalCharacteristics.map(
+          (characteristic) => characteristic.UUID,
+        ),
+      ).toContain(hap.Characteristic.StatusFault.UUID);
+    });
+
+    it("warns about a fault that was already present at startup", async () => {
+      // The earlier condition compared against `previous?.activeFaults.length`,
+      // which is undefined on the first update: a flat battery at start was
+      // never logged at all.
+      await startPlatform();
+
+      expect(log.warnings.join("\n")).toContain(
+        "Flur: TempZoneActuatorLowBattery.",
+      );
+    });
+
+    it("reports faults for the hot water too", async () => {
+      const status = fixture("locationStatus.json") as {
+        gateways: {
+          temperatureControlSystems: { dhw: { activeFaults: unknown[] } }[];
+        }[];
+      };
+      status.gateways[0]!.temperatureControlSystems[0]!.dhw.activeFaults = [
+        { faultType: "DHWSensorLowBattery", since: "2026-09-01T07:12:00Z" },
+      ];
+      fetchMock = routedFetch({ "/status": () => jsonResponse(status) });
+      vi.stubGlobal("fetch", fetchMock);
+      await startPlatform();
+      const accessory = accessoryNamed("Evohome Hot Water");
+
+      await expect(
+        serviceOf(accessory, hap.Service.Battery)
+          .getCharacteristic(hap.Characteristic.StatusLowBattery)
+          .handleGetRequest(),
+      ).resolves.toBe(hap.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
+      expect(log.warnings.join("\n")).toContain(
+        "Hot water: DHWSensorLowBattery.",
+      );
     });
   });
 

--- a/test/util/faults.test.ts
+++ b/test/util/faults.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  faultKey,
+  isLowBattery,
+  summarizeFaults,
+} from "../../src/util/faults.js";
+
+describe("isLowBattery", () => {
+  it("recognises the fault types the API actually sends", () => {
+    expect(isLowBattery("TempZoneActuatorLowBattery")).toBe(true);
+    expect(isLowBattery("TempZoneSensorLowBattery")).toBe(true);
+    expect(isLowBattery("DHWSensorLowBattery")).toBe(true);
+  });
+
+  it("recognises an unknown low-battery type as well", () => {
+    // The point of matching by substring: a fault type nobody has seen yet
+    // still ends up in the right category.
+    expect(isLowBattery("SomeNewThingLowBatteryWarning")).toBe(true);
+  });
+
+  it("does not mistake other faults for a battery", () => {
+    expect(isLowBattery("TempZoneActuatorCommunicationLost")).toBe(false);
+    expect(isLowBattery("BoilerCommunicationLost")).toBe(false);
+  });
+});
+
+describe("summarizeFaults", () => {
+  it("reports nothing without faults", () => {
+    expect(summarizeFaults([])).toEqual({ fault: false, lowBattery: false });
+  });
+
+  it("keeps a low battery out of StatusFault", () => {
+    // A valve with a weak battery still reports and still heats; declaring the
+    // zone faulty would be wrong.
+    expect(summarizeFaults(["TempZoneActuatorLowBattery"])).toEqual({
+      fault: false,
+      lowBattery: true,
+    });
+  });
+
+  it("treats a lost connection as a fault", () => {
+    expect(summarizeFaults(["TempZoneActuatorCommunicationLost"])).toEqual({
+      fault: true,
+      lowBattery: false,
+    });
+  });
+
+  it("reports both when both are present", () => {
+    expect(
+      summarizeFaults([
+        "TempZoneSensorLowBattery",
+        "TempZoneActuatorCommunicationLost",
+      ]),
+    ).toEqual({ fault: true, lowBattery: true });
+  });
+});
+
+describe("faultKey", () => {
+  it("ignores the order", () => {
+    // The API gives no guarantee about it, and a reordered list is not a change
+    // worth a second warning in the log.
+    expect(faultKey(["a", "b"])).toBe(faultKey(["b", "a"]));
+  });
+
+  it("distinguishes different sets", () => {
+    expect(faultKey(["a"])).not.toBe(faultKey(["a", "b"]));
+    expect(faultKey([])).not.toBe(faultKey(["a"]));
+  });
+});

--- a/test/util/setpoint.test.ts
+++ b/test/util/setpoint.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   decideOverride,
   DEFAULT_SETPOINT_STRATEGY,
+  needsSwitchpoint,
 } from "../../src/util/setpoint.js";
 
 import type { CurrentOverride } from "../../src/util/setpoint.js";
@@ -18,6 +19,12 @@ const runningOverride: CurrentOverride = {
 const followingSchedule: CurrentOverride = {
   setpointMode: "FollowSchedule",
   until: undefined,
+};
+
+/** The same override, but its end time has already passed. */
+const expiredOverride: CurrentOverride = {
+  setpointMode: "TemporaryOverride",
+  until: new Date("2026-03-22T12:00:00Z"),
 };
 
 /** Next switchpoint per the schedule: 18:00. */
@@ -169,5 +176,61 @@ describe("decideOverride", () => {
       expect(decision.mode).toBe("TemporaryOverride");
       expect(decision.until).toEqual(runningOverride.until);
     });
+  });
+});
+
+describe("needsSwitchpoint", () => {
+  // The accessories ask this before fetching a schedule. Every answer of
+  // `false` has to match a branch of decideOverride that ignores the
+  // switchpoint, otherwise a decision silently loses its end time.
+
+  it("never needs one for permanent", () => {
+    expect(needsSwitchpoint("permanent", followingSchedule, NOW)).toBe(false);
+    expect(needsSwitchpoint("permanent", runningOverride, NOW)).toBe(false);
+  });
+
+  it("does not need one while an override is running under keepExistingUntil", () => {
+    expect(needsSwitchpoint("keepExistingUntil", runningOverride, NOW)).toBe(
+      false,
+    );
+  });
+
+  it("needs one once the running override has expired", () => {
+    expect(needsSwitchpoint("keepExistingUntil", expiredOverride, NOW)).toBe(
+      true,
+    );
+  });
+
+  it("needs one when the zone is simply following its schedule", () => {
+    expect(needsSwitchpoint("keepExistingUntil", followingSchedule, NOW)).toBe(
+      true,
+    );
+  });
+
+  it("always needs one for untilNextSwitchpoint", () => {
+    expect(needsSwitchpoint("untilNextSwitchpoint", runningOverride, NOW)).toBe(
+      true,
+    );
+    expect(
+      needsSwitchpoint("untilNextSwitchpoint", followingSchedule, NOW),
+    ).toBe(true);
+  });
+
+  it("agrees with decideOverride wherever it says no", () => {
+    // The contract: if no switchpoint is needed, passing one changes nothing.
+    for (const current of [
+      runningOverride,
+      followingSchedule,
+      expiredOverride,
+    ]) {
+      for (const strategy of ["permanent", "keepExistingUntil"] as const) {
+        if (needsSwitchpoint(strategy, current, NOW)) {
+          continue;
+        }
+        expect(
+          decideOverride(strategy, current, nextSwitchpointAt, NOW),
+        ).toEqual(decideOverride(strategy, current, undefined, NOW));
+      }
+    }
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,13 +9,15 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "lcov"],
       include: ["src/**/*.ts"],
-      // Die Schwelle steigt mit jeder Phase und darf nie wieder sinken.
-      // Stand Phase 1 (API-Client): 95 % Zeilen, 90 % Branches.
+      // A ratchet: the thresholds track what the suite actually reaches and
+      // may only ever be raised. They were left at the phase 1 values for
+      // several phases, during which the real coverage quietly fell — the
+      // point of the ratchet is that this shows up as a failing build.
       thresholds: {
-        lines: 90,
-        functions: 90,
-        branches: 85,
-        statements: 90,
+        lines: 95,
+        functions: 98,
+        branches: 90,
+        statements: 95,
       },
     },
   },


### PR DESCRIPTION
Evohome reports an `activeFaults` list per zone and for the hot water. Until now
that list only ever reached the log, where nobody looks: a flat HR92 battery was
invisible in the Home app, even though Evohome says so explicitly — a zone
reports `TempZoneActuatorLowBattery` long before it stops sending a temperature
at all.

A new module, `src/util/faults.ts`, splits the faults into the two things
HomeKit can express:

| Fault reported by Evohome                               | In HomeKit                                     |
| :------------------------------------------------------ | :--------------------------------------------- |
| Low battery, e.g. `TempZoneActuatorLowBattery`          | `StatusLowBattery` on a battery service        |
| Anything else, e.g. `TempZoneActuatorCommunicationLost`  | `StatusFault` on the primary service           |

## Decisions worth reviewing

**A low battery is deliberately not a fault.** An HR92 with a weak battery still
measures and still heats. `StatusFault` should mean "these values are not
trustworthy", which is true only for a real failure — radio link lost, sensor
defective.

**Fault types are matched by substring, not against a list of known names.**
Resideo adds fault types without announcing them, and a closed list would
silently ignore whatever is not on it — the same trap as the `modelType`
allowlist.

**The battery service carries no `BatteryLevel`.** The API reports whether a
battery is low, never how full it is, and an invented percentage would be worse
than none — the same reasoning as for the missing hot water history. Every zone
gets a battery service, including mains-powered ones such as `ZoneValves`; those
simply never report a battery fault. Leaving the service out would need an
allowlist by zone type, which goes stale the moment a new model appears.

## A bug fixed along the way

The log line read:

```ts
status.activeFaults.length > 0 && previous?.activeFaults.length === 0
```

On the first update `previous` is undefined, so `undefined === 0` is false: a
zone whose battery was already flat when Homebridge started was **never** logged,
and a cleared fault was not reported either. Faults are now logged whenever the
set of them changes, in both directions, compared through sorted keys because the
API guarantees no order.

## Two details

- `StatusFault` is not among the optional characteristics HAP declares for the
  thermostat service (it is for the hot water's temperature sensor). Without
  `addOptionalCharacteristic` it is still added, but with an "Adding anyway"
  characteristic warning per zone on every start. A test covers this; removing
  the call makes it fail, and the warning does appear.
- `DhwStatus` never parsed `activeFaults` at all, although the fixture contains
  them.

## Testing

`npm run check` passes: lint, typecheck and 203 tests. New are 9 unit tests for
`faults.ts` (100 % coverage of the module) and 6 integration tests in
`platform.test.ts` that drive the real HAP through the platform.

Not verified against a real system with domestic hot water — the same gap that
still blocks 1.0.0.

## Not for merging yet

This waits on the `1.0.0-beta.0` feedback. The CHANGELOG entry sits under
`## Unreleased`; `1.0.0-beta.0` is already published under the `beta` tag and its
section is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DMZ33GMXDpvQivQUFip7Qd
