### PR TITLE
ci: bump checkout and setup-node to v7, codeql-action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
         node: [22, 24, 26]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           cache: npm
@@ -46,8 +46,8 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -69,4 +69,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,15 +18,15 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@v7
         with:
           # Not the lowest supported version: trusted publishing needs npm
           # 11.5.1 or newer, and Node 22 still ships npm 10.9.
           node-version: 24
           registry-url: https://registry.npmjs.org
-          # setup-node caches by default in v6. Its own docs advise turning
+          # setup-node caches by default since v6. Its own docs advise turning
           # that off in publishing workflows, because a poisoned cache could
           # expose credentials — including the OIDC token.
           package-manager-cache: false


### PR DESCRIPTION
What Dependabot asked for in #210 (`actions/checkout` 5 → 7), #212
(`actions/setup-node` 5 → 7) and #196 (`github/codeql-action` 3 → 4), applied by
hand in one commit rather than merged one branch at a time. #196 also predates
the 1.0.0 merge.

`actions/setup-node@v7` drops the dummy `NODE_AUTH_TOKEN` export, which is one
less thing in the way of the trusted publishing the release workflow uses. The
`package-manager-cache: false` that workflow sets — caching is on by default
since v6, and turning it off is what setup-node's own docs advise for a
publishing job — is unchanged in v7.

Closes #210, closes #212, closes #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Dyv1cJnNGw6L4K1U6LNRg