### PR TITLE
ci: drop the merged homebridge-v2 branch from the triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master, homebridge-v2]
+    branches: [master]
   pull_request:
-    branches: [master, homebridge-v2]
+    branches: [master]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The rewrite landed on `master` with 1.0.0 and the branch is deleted, so the
second entry in both trigger lists matched nothing.

Pull requests against `master` still run the same checks whatever branch they
come from, so nothing loses coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Dyv1cJnNGw6L4K1U6LNRg