### PR TITLE
fix(auth): log in again when a refresh is refused without invalid_grant

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -62,6 +62,24 @@ interface OAuthErrorBody {
  */
 const PERMANENT_ERRORS = new Set(["invalid_grant", "unauthorized_client"]);
 
+/**
+ * Is repeating an identical `refresh_token` request the right answer?
+ *
+ * Only when the server never judged the token: it was overloaded (5xx) or it
+ * turned us away for volume (429). Everything else — any 4xx, and the 200 with
+ * an `error` field the TCC API also uses — is a verdict on *this* refresh
+ * token, and sending it again cannot produce a different one. Such a refusal
+ * has to fall through to a full login.
+ *
+ * Only `invalid_grant` used to take that route, so a 400 carrying any other
+ * code, or none at all, was classified retryable and repeated for as long as
+ * Homebridge ran. That is the "Renewing Honeywell API authentication token
+ * failed: HTTP error 400 / every half hour / for weeks" of 0.11.2 (issue
+ * #136) rebuilt behind a backoff.
+ */
+const refreshWorthRepeating = (error: EvohomeAuthError): boolean =>
+  error.status === 429 || (error.status ?? 0) >= 500;
+
 export class TokenStore {
   private tokens: Tokens | undefined;
 
@@ -176,7 +194,7 @@ export class TokenStore {
         refresh_token: refreshToken,
       });
     } catch (error) {
-      if (error instanceof EvohomeAuthError && !error.retryable) {
+      if (error instanceof EvohomeAuthError && !refreshWorthRepeating(error)) {
         return undefined;
       }
       throw error;
@@ -258,6 +276,7 @@ export class TokenStore {
     return new EvohomeAuthError(
       `Evohome login failed (HTTP ${String(status)}): ${detail}.${hint}`,
       !permanent,
+      status,
     );
   }
 }

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -21,11 +21,16 @@ export class EvohomeError extends Error {
  * `retryable` separates the permanent case (wrong password: retrying achieves
  * nothing and only runs into the rate limit) from the temporary one (expired
  * refresh token, server error during login).
+ *
+ * `status` is the HTTP status the token endpoint answered with. `TokenStore`
+ * needs it to tell a rejected refresh token from an endpoint that was simply
+ * unreachable, because only the first is worth a re-login (issue #136).
  */
 export class EvohomeAuthError extends EvohomeError {
   constructor(
     message: string,
     readonly retryable: boolean,
+    readonly status?: number,
     options?: { cause?: unknown },
   ) {
     super(message, options);

--- a/test/api/auth.test.ts
+++ b/test/api/auth.test.ts
@@ -116,6 +116,76 @@ describe("TokenStore", () => {
     expect(bodyOf(fetchMock.mock.calls[1]!).get("grant_type")).toBe("password");
   });
 
+  it("logs in again when the refresh is refused without invalid_grant", async () => {
+    // @PuzzledUser on #136: "Renewing Honeywell API authentication token
+    // failed: HTTP error 400" every half hour for weeks, on 0.11.2. A 400 is
+    // the endpoint judging this refresh token, whatever code it carries, so
+    // repeating it is pointless — only a login gets out of that loop.
+    const cache = memoryCache();
+    cache.value = {
+      accessToken: "alt",
+      refreshToken: "abgelehnt",
+      expiresAt: Date.now() - 1000,
+    };
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse("Bad Request", { status: 400 }),
+    );
+    fetchMock.mockResolvedValueOnce(jsonResponse(tokenBody("neu", "frisch")));
+
+    const store = new TokenStore("u", "p", cache);
+    expect(await store.authorization()).toBe("bearer neu");
+
+    expect(bodyOf(fetchMock.mock.calls[0]!).get("grant_type")).toBe(
+      "refresh_token",
+    );
+    expect(bodyOf(fetchMock.mock.calls[1]!).get("grant_type")).toBe("password");
+  });
+
+  it("logs in again when the refresh error arrives with HTTP 200", async () => {
+    const cache = memoryCache();
+    cache.value = {
+      accessToken: "alt",
+      refreshToken: "abgelehnt",
+      expiresAt: Date.now() - 1000,
+    };
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "invalid_request" }));
+    fetchMock.mockResolvedValueOnce(jsonResponse(tokenBody("neu", "frisch")));
+
+    const store = new TokenStore("u", "p", cache);
+    expect(await store.authorization()).toBe("bearer neu");
+    expect(bodyOf(fetchMock.mock.calls[1]!).get("grant_type")).toBe("password");
+  });
+
+  it("keeps the refresh token when the endpoint is merely down", async () => {
+    // The other half of the rule: a 5xx or a 429 says nothing about the token,
+    // so spending a password login on it would only add rate-limit pressure.
+    // The poller retries with backoff instead.
+    const cache = memoryCache();
+    const tokens = {
+      accessToken: "alt",
+      refreshToken: "gueltig",
+      expiresAt: Date.now() - 1000,
+    };
+    cache.value = { ...tokens };
+
+    fetchMock.mockResolvedValue(
+      jsonResponse("<html>503</html>", { status: 503 }),
+    );
+
+    const store = new TokenStore("u", "p", cache);
+    await expect(store.authorization()).rejects.toSatisfy(
+      (error: unknown) => error instanceof EvohomeAuthError && error.retryable,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(bodyOf(fetchMock.mock.calls[0]!).get("grant_type")).toBe(
+      "refresh_token",
+    );
+    expect(cache.value).toEqual(tokens);
+  });
+
   it("gives up on bad credentials instead of running into the rate limit", async () => {
     // A Response body can only be read once, so build a fresh one per call.
     fetchMock.mockImplementation(() =>


### PR DESCRIPTION
Found from new feedback on #136: @PuzzledUser's 0.11.2 log
(`Renewing Honeywell API authentication token failed: HTTP error 400`, every
half hour for weeks) sent me back into the rewritten auth path, and the
fallback there was not complete.

`tryRefresh()` fell through to a full login only when the response body carried
`invalid_grant`. A 400 with any other code, or none at all, was classified
retryable, so `acquire()` presented the same spent refresh token again on the
next poll — behind a backoff, but with no way out. That is the failure mode
#136 was filed for, one door further in. The HTTP 200 with an `error` field the
TCC API also uses had the same hole.

A refresh is now repeated only when the answer says nothing about the token —
429 and 5xx. Everything else is a verdict on *this* refresh token and leads to
a login. The other half matters as much and is tested: a 503 must **not** burn
a password login, because Honeywell's rate limit is per account and a login
under pressure only adds to it.

- `EvohomeAuthError` carries the HTTP status, which is what the decision needs.
- Three tests; two of them fail without the fix (verified by reverting the
  classification), the third is the guard against over-correcting.
- `npm run check` green, 274 tests, `src/api/auth.ts` at 100 % statements.

No CHANGELOG entry — that goes in when a release is cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZxkNXzStduYe5578utunW
